### PR TITLE
feat: 예약중 메뉴선택 UI추가

### DIFF
--- a/src/components/reservation/PaymentModal.tsx
+++ b/src/components/reservation/PaymentModal.tsx
@@ -8,6 +8,7 @@ import { useMenus } from "@/hooks/useMenus";
 import { useDepositRate } from "@/hooks/useDepositRate";
 import { calcMenuTotal } from "@/utils/menu";
 import { calcDeposit } from "@/utils/payment";
+import { useConfirmClose } from "@/hooks/useConfirmClose";
 
 type PayMethod = "KAKAOPAY" | "TOSSPAY";
 
@@ -18,7 +19,6 @@ type Props = {
   restaurant: Restaurant;
   draft: ReservationDraft;
   onSuccess: () => void;
-  onBack: () => void;
 };
 
 function mockPay(method: PayMethod, amount: number) {
@@ -35,7 +35,6 @@ export default function PaymentModal({
   restaurant,
   draft,
   onSuccess,
-  onBack,
 }: Props) {
   const [method, setMethod] = useState<PayMethod | undefined>();
   const [loading, setLoading] = useState(false);
@@ -63,18 +62,7 @@ export default function PaymentModal({
     }
   };
 
-  const handleBack = () => {
-    onOpenChange(false);
-    onBack();
-  };
-
-  const handleRequestClose = () => {
-    const ok = window.confirm(
-      "예약금이 결제되지 않았습니다. \n 예약화면을 벗어나시겠습니까?",
-    );
-    if (ok) onClose();
-  };
-
+  const handleRequestClose = useConfirmClose(onClose);
   if (!open) return null;
 
   return (
@@ -96,7 +84,7 @@ export default function PaymentModal({
           <h3 className="text-lg">예약금 결제</h3>
           <button
             type="button"
-            onClick={handleBack}
+            onClick={handleRequestClose}
             aria-label="닫기"
             className="p-2 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
           >

--- a/src/components/reservation/PaymentModal.tsx
+++ b/src/components/reservation/PaymentModal.tsx
@@ -4,6 +4,10 @@ import { formatKrw } from "@/utils/money";
 import { Button } from "../ui/button";
 import { cn } from "@/lib/utils";
 import { X } from "lucide-react";
+import { useMenus } from "@/hooks/useMenus";
+import { useDepositRate } from "@/hooks/useDepositRate";
+import { calcMenuTotal } from "@/utils/menu";
+import { calcDeposit } from "@/utils/payment";
 
 type PayMethod = "KAKAOPAY" | "TOSSPAY";
 
@@ -36,7 +40,16 @@ export default function PaymentModal({
   const [method, setMethod] = useState<PayMethod | undefined>();
   const [loading, setLoading] = useState(false);
 
-  const amount = useMemo(() => draft.payment.depositAmount, [draft.payment]);
+  const { menus } = useMenus(restaurant.id);
+  const { rate } = useDepositRate(restaurant.id);
+
+  const menuTotal = useMemo(() => {
+    return calcMenuTotal(menus, draft.selectedMenus);
+  }, [menus, draft.selectedMenus]);
+
+  const amount = useMemo(() => {
+    return calcDeposit(menuTotal, rate);
+  }, [menuTotal, rate]);
 
   const onClickPay = async () => {
     if (loading) return;
@@ -96,13 +109,18 @@ export default function PaymentModal({
             <div className="text-sm text-muted-foreground">매장</div>
             <div className="mt-1 text-base truncate">{restaurant.name}</div>
           </div>
-          <div className="border rounded-xl p-4 flex items-center justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-sm text-muted-foreground">결제 금액</div>
-              <div className="mt-1 text-xl font-semibold">
-                {formatKrw(amount)}원
+          <div className="border rounded-xl p-4 space-y-1">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-sm text-muted-foreground">결제 금액</div>
+                <div className="mt-1 text-xl font-semibold">
+                  {formatKrw(amount)}원
+                </div>
               </div>
             </div>
+            <p className="text-xs text-muted-foreground">
+              메뉴 총액 {formatKrw(menuTotal)}원 * {Math.round(rate * 100)}%
+            </p>
           </div>
           {/* 본문 */}
           <div className="space-y-2">

--- a/src/components/reservation/ReservationConfirmModal.tsx
+++ b/src/components/reservation/ReservationConfirmModal.tsx
@@ -29,9 +29,7 @@ export default function ReservationConfirmMoodal({
 }: Props) {
   const { people, date, time, seatType, tablePref } = draft;
 
-  //UI테스트를 위해서 r-1로 고정함. 나중에 백엔드 연결시 주석으로 변경필요. ReservationModal또한 변경필요.
-  // const layout = getMockLayoutByRestaurantId(restaurant.id ?? "r-1");
-  const layout = getMockLayoutByRestaurantId("1");
+  const layout = getMockLayoutByRestaurantId(restaurant.id ?? "1");
 
   const seatTable = layout?.tables.find((t) => t.id === draft.tableId);
 

--- a/src/components/reservation/ReservationConfirmModal.tsx
+++ b/src/components/reservation/ReservationConfirmModal.tsx
@@ -32,7 +32,7 @@ export default function ReservationConfirmMoodal({
 
   //UI테스트를 위해서 r-1로 고정함. 나중에 백엔드 연결시 주석으로 변경필요. ReservationModal또한 변경필요.
   // const layout = getMockLayoutByRestaurantId(restaurant.id ?? "r-1");
-  const layout = getMockLayoutByRestaurantId("r-1");
+  const layout = getMockLayoutByRestaurantId("1");
 
   const seatTable = layout?.tables.find((t) => t.id === draft.tableId);
 
@@ -110,10 +110,10 @@ export default function ReservationConfirmMoodal({
           <div className="border rounded-lg p-3 bg-blue-50 border-blue-200">
             <div className="text-sm text-gray-500">결제 유형</div>
             <div className="text-blue-700">사전 결제</div>
-            <div className="text-sm text-gray-800 mt-1">
-              예약금: {formatKrw(menuTotal)}원 ({Math.round(rate * 100)}% 적용)
+            <div className="text-gray-800 mt-1 font-semibold">
+              예약금: {formatKrw(depositAmount)}원
             </div>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-muted-foreground mt-2">
               {restaurant.paymentPolicy?.notice ??
                 "예약 확정을 위해 예약금 결제가 필요합니다.(노쇼 방지 목적)"}
             </p>

--- a/src/components/reservation/ReservationConfirmModal.tsx
+++ b/src/components/reservation/ReservationConfirmModal.tsx
@@ -26,8 +26,6 @@ export default function ReservationConfirmMoodal({
   restaurant,
   draft,
 }: Props) {
-  if (!open) return null;
-
   const { people, date, time, seatType, tablePref } = draft;
 
   //UI테스트를 위해서 r-1로 고정함. 나중에 백엔드 연결시 주석으로 변경필요. ReservationModal또한 변경필요.
@@ -48,6 +46,8 @@ export default function ReservationConfirmMoodal({
   const { selectedMenus } = draft;
   const menuTotal = calcMenuTotal(menus, selectedMenus);
   const depositAmount = calcDeposit(menuTotal, rate);
+
+  if (!open) return null;
 
   return (
     <div

--- a/src/components/reservation/ReservationConfirmModal.tsx
+++ b/src/components/reservation/ReservationConfirmModal.tsx
@@ -1,3 +1,4 @@
+import { useConfirmClose } from "@/hooks/useConfirmClose";
 import { useDepositRate } from "@/hooks/useDepositRate";
 import { useMenus } from "@/hooks/useMenus";
 import { getMockLayoutByRestaurantId } from "@/mock/seatLayout";
@@ -34,12 +35,7 @@ export default function ReservationConfirmMoodal({
 
   const seatTable = layout?.tables.find((t) => t.id === draft.tableId);
 
-  const handleRequestClose = () => {
-    const ok = window.confirm(
-      "예약이 확정되지 않았습니다.\n예약화면을 벗어나시겠습니까?",
-    );
-    if (ok) onClose();
-  };
+  const handleRequestClose = useConfirmClose(onClose);
 
   const { menus } = useMenus(restaurant.id);
   const { rate } = useDepositRate(restaurant.id);

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -253,11 +253,14 @@ export default function ReservationMenuModal({
         <div className="border-t px-6 py-3 bg-white space-y-3">
           <div className="flex items-center justify-between">
             <div>
-              <div className="text-sm text-muted-foreground">메뉴 총액</div>
-              <div className="text-lg font-semibold">
-                {formatKrw(totalPrice)}
+              <div className="text-muted-foreground">
+                메뉴 총액: {""}
+                <span className="text-lg font-semibold">
+                  {formatKrw(totalPrice)}
+                </span>
               </div>
-              <div className="mt-1 text-sm text-muted-foreground">
+
+              <div className="mt-1 text-xl text-blue-600 font-semibold">
                 예약금 ({Math.round(rate * 100)}%): {""}
                 <span>{formatKrw(depositAmount)}</span>
               </div>

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -227,11 +227,11 @@ export default function ReservationMenuModal({
                                     type="button"
                                     className={cn(
                                       "h-9 w-9 border rounded-lg flex items-center justify-center cursor-pointer hover:bg-gray-100",
-                                      menu.isSoldOut &&
+                                      (menu.isSoldOut || qty >= 20) &&
                                         "opacity-40 cursor-not-allowed",
                                     )}
                                     onClick={() => inc(menu)}
-                                    disabled={menu.isSoldOut}
+                                    disabled={menu.isSoldOut || qty >= 20}
                                     aria-label={`${menu.name} 수량증가`}
                                   >
                                     <Plus className="h-4 w-4" />

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -1,3 +1,56 @@
-export default function ReservationMenuModal() {
-  return <div>메뉴 선택모달</div>;
+import type { ReservationDraft, Restaurant } from "@/types/restaurant";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  restaurant: Restaurant;
+  onConfirm: (draft: ReservationDraft) => void;
+  onBack: () => void;
+  draft: ReservationDraft;
+};
+
+export default function ReservationMenuModal({
+  open,
+  onOpenChange,
+  restaurant,
+  onConfirm,
+  onBack,
+  draft,
+}: Props) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      aria-modal="true"
+      role="dialog"
+      aria-label="식당 예약 모달"
+    >
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/50"
+        aria-label="모달 닫기"
+        onClick={() => onOpenChange(false)}
+      />
+      <div className="relative z-10 w-[92vw] max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-xl overflow-hidden">
+        <div className="flex items-center justify-between px-5 py-4 border-b">
+          <h2>{restaurant.name} 메뉴선택</h2>
+          <button
+            type="button"
+            className="px-3 py-2 rounded-lg hover:bg-gray-100"
+            onClick={onBack}
+          >
+            뒤로
+          </button>
+        </div>
+        <p className="mt-4 text-sm text-muted-foreground">메뉴선택UI</p>
+        <button
+          type="button"
+          className="mt-6 w-full rounded-xl bg-blue-500 text-white py-3 hover:bg-blue-600"
+          onClick={() => onConfirm(draft)}
+        >
+          다음
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -19,7 +19,7 @@ type Props = {
   draft: ReservationDraft;
 };
 
-const CategotyLabel: Record<MenuCategory, string> = {
+const CategoryLabel: Record<MenuCategory, string> = {
   MAIN: "메인 메뉴",
   SIDE: "사이드 메뉴",
   DRINK: "음료",
@@ -40,7 +40,6 @@ export default function ReservationMenuModal({
   );
 
   useEffect(() => {
-    if (!open) return;
     setSelectedMenus(draft.selectedMenus ?? []);
   }, [open, draft.selectedMenus]);
 
@@ -99,6 +98,8 @@ export default function ReservationMenuModal({
     [totalPrice, rate],
   );
 
+  if (!open) return;
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
@@ -143,7 +144,7 @@ export default function ReservationMenuModal({
 
               return (
                 <section key={cat} className="space-y-3">
-                  <div className="font-semibold">{CategotyLabel[cat]}</div>
+                  <div className="font-semibold">{CategoryLabel[cat]}</div>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                     {list.map((menu) => {
                       const qty = qtyMap.get(menu.id) ?? 0;

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -125,8 +125,8 @@ export default function ReservationMenuModal({
           <button
             type="button"
             className="p-2 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
-            onClick={onBack}
-            aria-label="예약모달로 돌아가기"
+            onClick={() => onOpenChange(false)}
+            aria-label="모달 닫기"
           >
             <X />
           </button>
@@ -265,13 +265,23 @@ export default function ReservationMenuModal({
                 <span>{formatKrw(depositAmount)}</span>
               </div>
             </div>
-            <Button
-              type="button"
-              className="h-12 px-6 rounded-lg cursor-pointer bg-blue-500  hover:bg-blue-600"
-              onClick={() => onConfirm({ ...draft, selectedMenus })}
-            >
-              다음
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                className="h-12 px-6 rounded-lg cursor-pointer"
+                variant="outline"
+                onClick={onBack}
+              >
+                이전
+              </Button>
+              <Button
+                type="button"
+                className="h-12 px-6 rounded-lg cursor-pointer bg-blue-500  hover:bg-blue-600"
+                onClick={() => onConfirm({ ...draft, selectedMenus })}
+              >
+                다음
+              </Button>
+            </div>
           </div>
           <p className="text-xs text-muted-foreground">
             실제 결제는 다음 단계에서 진행됩니다

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -116,7 +116,7 @@ export default function ReservationMenuModal({
         type="button"
         className="absolute inset-0 bg-black/50"
         aria-label="모달 닫기"
-        onClick={() => onOpenChange(false)}
+        onClick={handleRequestClose}
       />
       <div className="flex flex-col relative z-10 w-[92vw] max-w-4xl max-h-[calc(100vh-96px)] overflow-y-auto rounded-2xl bg-white shadow-xl overflow-hidden">
         <div className="flex items-center justify-between px-6 py-4 border-b">

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { formatKrw } from "@/utils/money";
 import { useDepositRate } from "@/hooks/useDepositRate";
 import { calcDeposit } from "@/utils/payment";
+import { useConfirmClose } from "@/hooks/useConfirmClose";
 
 type Props = {
   open: boolean;
@@ -16,6 +17,7 @@ type Props = {
   restaurant: Restaurant;
   onConfirm: (draft: ReservationDraft) => void;
   onBack: () => void;
+  onClose: () => void;
   draft: ReservationDraft;
 };
 
@@ -31,6 +33,7 @@ export default function ReservationMenuModal({
   restaurant,
   onConfirm,
   onBack,
+  onClose,
   draft,
 }: Props) {
   const { activeMenus } = useMenus(restaurant.id);
@@ -98,6 +101,8 @@ export default function ReservationMenuModal({
     [totalPrice, rate],
   );
 
+  const handleRequestClose = useConfirmClose(onClose);
+
   if (!open) return;
 
   return (
@@ -125,7 +130,7 @@ export default function ReservationMenuModal({
           <button
             type="button"
             className="p-2 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
-            onClick={() => onOpenChange(false)}
+            onClick={handleRequestClose}
             aria-label="모달 닫기"
           >
             <X />

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -1,0 +1,3 @@
+export default function ReservationMenuModal() {
+  return <div>메뉴 선택모달</div>;
+}

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -3,7 +3,7 @@ import { Minus, Plus, X } from "lucide-react";
 import { Button } from "../ui/button";
 import type { SelectedMenu, MenuCategory, MenuItem } from "@/types/menus";
 import { useMenus } from "@/hooks/useMenus";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { calcMenuTotal } from "@/utils/menu";
 import { cn } from "@/lib/utils";
 import { formatKrw } from "@/utils/money";
@@ -33,13 +33,17 @@ export default function ReservationMenuModal({
   onBack,
   draft,
 }: Props) {
-  if (!open) return null;
-
   const { activeMenus } = useMenus(restaurant.id);
 
   const [selectedMenus, setSelectedMenus] = useState<SelectedMenu[]>(
     draft.selectedMenus ?? [],
   );
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedMenus(draft.selectedMenus ?? []);
+  }, [open, draft.selectedMenus]);
+
   const qtyMap = useMemo(() => {
     const map = new Map<string, number>();
     for (const s of selectedMenus) map.set(s.menuId, s.quantity);
@@ -100,7 +104,7 @@ export default function ReservationMenuModal({
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
       aria-modal="true"
       role="dialog"
-      aria-label="식당 예약 모달"
+      aria-label="메뉴 선택 모달"
     >
       <button
         type="button"

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -1,4 +1,14 @@
 import type { ReservationDraft, Restaurant } from "@/types/restaurant";
+import { Minus, Plus, X } from "lucide-react";
+import { Button } from "../ui/button";
+import type { SelectedMenu, MenuCategory, MenuItem } from "@/types/menus";
+import { useMenus } from "@/hooks/useMenus";
+import { useMemo, useState } from "react";
+import { calcMenuTotal } from "@/utils/menu";
+import { cn } from "@/lib/utils";
+import { formatKrw } from "@/utils/money";
+import { useDepositRate } from "@/hooks/useDepositRate";
+import { calcDeposit } from "@/utils/payment";
 
 type Props = {
   open: boolean;
@@ -7,6 +17,12 @@ type Props = {
   onConfirm: (draft: ReservationDraft) => void;
   onBack: () => void;
   draft: ReservationDraft;
+};
+
+const CategotyLabel: Record<MenuCategory, string> = {
+  MAIN: "메인 메뉴",
+  SIDE: "사이드 메뉴",
+  DRINK: "음료",
 };
 
 export default function ReservationMenuModal({
@@ -18,6 +34,67 @@ export default function ReservationMenuModal({
   draft,
 }: Props) {
   if (!open) return null;
+
+  const { activeMenus } = useMenus(restaurant.id);
+
+  const [selectedMenus, setSelectedMenus] = useState<SelectedMenu[]>(
+    draft.selectedMenus ?? [],
+  );
+  const qtyMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const s of selectedMenus) map.set(s.menuId, s.quantity);
+    return map;
+  }, [selectedMenus]);
+
+  const grouped = useMemo(() => {
+    const by: Record<MenuCategory, MenuItem[]> = {
+      MAIN: [],
+      SIDE: [],
+      DRINK: [],
+    };
+    for (const m of activeMenus) by[m.category].push(m);
+    return by;
+  }, [activeMenus]);
+
+  const totalPrice = useMemo(() => {
+    return calcMenuTotal(activeMenus, selectedMenus);
+  }, [activeMenus, selectedMenus]);
+
+  const setQuantity = (menu: MenuItem, nextQty: number) => {
+    if (menu.isSoldOut) return;
+
+    // 메뉴 최대 수량 20개로 제한
+    const q = Math.max(0, Math.min(20, nextQty));
+    setSelectedMenus((prev) => {
+      const exists = prev.find((p) => p.menuId === menu.id);
+
+      if (q === 0) return prev.filter((p) => p.menuId !== menu.id);
+
+      if (exists) {
+        return prev.map((p) =>
+          p.menuId === menu.id ? { ...p, quantity: q } : p,
+        );
+      }
+
+      return [...prev, { menuId: menu.id, quantity: q }];
+    });
+  };
+
+  const inc = (menu: MenuItem) => {
+    const cur = qtyMap.get(menu.id) ?? 0;
+    setQuantity(menu, cur + 1);
+  };
+  const dec = (menu: MenuItem) => {
+    const cur = qtyMap.get(menu.id) ?? 0;
+    setQuantity(menu, cur - 1);
+  };
+
+  const { rate } = useDepositRate(restaurant.id);
+  const depositAmount = useMemo(
+    () => calcDeposit(totalPrice, rate),
+    [totalPrice, rate],
+  );
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
@@ -31,25 +108,167 @@ export default function ReservationMenuModal({
         aria-label="모달 닫기"
         onClick={() => onOpenChange(false)}
       />
-      <div className="relative z-10 w-[92vw] max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-xl overflow-hidden">
+      <div className="flex flex-col relative z-10 w-[92vw] max-w-4xl max-h-[calc(100vh-96px)] overflow-y-auto rounded-2xl bg-white shadow-xl overflow-hidden">
         <div className="flex items-center justify-between px-5 py-4 border-b">
-          <h2>{restaurant.name} 메뉴선택</h2>
+          <div>
+            <h2 className="text-xl truncate">{restaurant.name} 메뉴선택</h2>
+            <p className="text-sm text-muted-foreground truncate">
+              원하시는 메뉴를 미리 선택할 수 있어요. 메뉴당 최대수량은
+              20개입니다.
+            </p>
+          </div>
           <button
             type="button"
-            className="px-3 py-2 rounded-lg hover:bg-gray-100"
+            className="p-2 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
             onClick={onBack}
+            aria-label="예약모달로 돌아가기"
           >
-            뒤로
+            <X />
           </button>
         </div>
-        <p className="mt-4 text-sm text-muted-foreground">메뉴선택UI</p>
-        <button
-          type="button"
-          className="mt-6 w-full rounded-xl bg-blue-500 text-white py-3 hover:bg-blue-600"
-          onClick={() => onConfirm(draft)}
-        >
-          다음
-        </button>
+        {/* 메뉴선택UI */}
+        <div className="overflow-y-auto px-6 py-6 space-y-7">
+          {activeMenus.length === 0 ? (
+            <div className="border rounded-xl p-6 text-center text-sm text-muted-foreground">
+              아직 등록된 메뉴가 없어요
+            </div>
+          ) : (
+            (["MAIN", "SIDE", "DRINK"] as MenuCategory[]).map((cat) => {
+              const list = grouped[cat];
+              if (list.length === 0) return null;
+
+              return (
+                <section key={cat} className="space-y-3">
+                  <div className="font-semibold">{CategotyLabel[cat]}</div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    {list.map((menu) => {
+                      const qty = qtyMap.get(menu.id) ?? 0;
+                      const img =
+                        menu.imageUrl && menu.imageUrl.trim().length > 0
+                          ? menu.imageUrl
+                          : "/modernKoreaRestaurant.jpg";
+                      return (
+                        <div
+                          key={menu.id}
+                          className={cn(
+                            "rounded-2xl border overflow-hidden bg-white transition",
+                            menu.isSoldOut
+                              ? "opacity-50 cursor-not-allowed"
+                              : "hover:shadow-sm",
+                          )}
+                          aria-disabled={menu.isSoldOut}
+                        >
+                          <div className="flex gap-4 p-4">
+                            {/* 음식사진 */}
+                            <div className="relative h-28 w-28 shrink-0 overflow-hidden rounded-xl">
+                              <img
+                                src={img}
+                                alt={menu.name}
+                                className={cn(
+                                  "h-full w-full object-cover",
+                                  menu.isSoldOut && "grayscale",
+                                )}
+                              />
+                              {menu.isSoldOut && (
+                                <div className="absolute inset-0 grid place-items-center bg-black/40">
+                                  <span className="rounded-sm bg-black/70 px-3 py-1 font-semibold text-white">
+                                    품절
+                                  </span>
+                                </div>
+                              )}
+                            </div>
+                            {/* 내용 */}
+                            <div className="flex-1 p-4 min-w-0 flex flex-col justify-between gap-3">
+                              <div className="min-w-0">
+                                <div className="flex items-start justify-between gap-2">
+                                  <div className="min-w-0">
+                                    <p className="font-medium truncate">
+                                      {menu.name}
+                                    </p>
+                                    {menu.description ? (
+                                      <p className="text-sm text-muted-foreground line-clamp-2 mt-1">
+                                        {menu.description}
+                                      </p>
+                                    ) : null}
+                                  </div>
+                                  {qty > 0 ? (
+                                    <span className="shrink-0 rounded-md bg-blue-50 text-blue-600 px-2 py-1 text-md">
+                                      {qty}개
+                                    </span>
+                                  ) : null}
+                                </div>
+                                <p className="mt-2 text-sm font-semibold">
+                                  {formatKrw(menu.price)}원
+                                </p>
+                              </div>
+                              {/* 수량 조절 */}
+                              <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-2">
+                                  <button
+                                    type="button"
+                                    className={cn(
+                                      "h-9 w-9 border rounded-lg flex items-center justify-center cursor-pointer hover:bg-gray-100",
+                                      (qty === 0 || menu.isSoldOut) &&
+                                        "opacity-40 cursor-not-allowed",
+                                    )}
+                                    onClick={() => dec(menu)}
+                                    disabled={qty === 0 || menu.isSoldOut}
+                                    aria-label={`${menu.name} 수량 감소`}
+                                  >
+                                    <Minus className="h-4 w-4" />
+                                  </button>
+                                  <span>{qty}</span>
+                                  <button
+                                    type="button"
+                                    className={cn(
+                                      "h-9 w-9 border rounded-lg flex items-center justify-center cursor-pointer hover:bg-gray-100",
+                                      menu.isSoldOut &&
+                                        "opacity-40 cursor-not-allowed",
+                                    )}
+                                    onClick={() => inc(menu)}
+                                    disabled={menu.isSoldOut}
+                                    aria-label={`${menu.name} 수량증가`}
+                                  >
+                                    <Plus className="h-4 w-4" />
+                                  </button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </section>
+              );
+            })
+          )}
+        </div>
+
+        <div className="border-t px-6 py-3 bg-white space-y-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm text-muted-foreground">메뉴 총액</div>
+              <div className="text-lg font-semibold">
+                {formatKrw(totalPrice)}
+              </div>
+              <div className="mt-1 text-sm text-muted-foreground">
+                예약금 ({Math.round(rate * 100)}%): {""}
+                <span>{formatKrw(depositAmount)}</span>
+              </div>
+            </div>
+            <Button
+              type="button"
+              className="h-12 px-6 rounded-lg cursor-pointer bg-blue-500  hover:bg-blue-600"
+              onClick={() => onConfirm({ ...draft, selectedMenus })}
+            >
+              다음
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            실제 결제는 다음 단계에서 진행됩니다
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/components/reservation/ReservationMenuModal.tsx
+++ b/src/components/reservation/ReservationMenuModal.tsx
@@ -114,8 +114,8 @@ export default function ReservationMenuModal({
         onClick={() => onOpenChange(false)}
       />
       <div className="flex flex-col relative z-10 w-[92vw] max-w-4xl max-h-[calc(100vh-96px)] overflow-y-auto rounded-2xl bg-white shadow-xl overflow-hidden">
-        <div className="flex items-center justify-between px-5 py-4 border-b">
-          <div>
+        <div className="flex items-center justify-between px-6 py-4 border-b">
+          <div className="min-w-0">
             <h2 className="text-xl truncate">{restaurant.name} 메뉴선택</h2>
             <p className="text-sm text-muted-foreground truncate">
               원하시는 메뉴를 미리 선택할 수 있어요. 메뉴당 최대수량은

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -287,22 +287,23 @@ export default function ReservationModal({
               </p>
             )}
             {layout && canQueryTables && (
-              <>
-                <TableMap
-                  layout={layout}
-                  availableIds={availableIds}
-                  selectedTableId={selectedTableId}
-                  seatType={seatType}
-                  onSelectTable={setSelectedTableId}
-                  onSelectSeatType={setSeatType}
-                />
-
+              <div className="overflow-x-auto">
+                <div className="min-w-[500px]">
+                  <TableMap
+                    layout={layout}
+                    availableIds={availableIds}
+                    selectedTableId={selectedTableId}
+                    seatType={seatType}
+                    onSelectTable={setSelectedTableId}
+                    onSelectSeatType={setSeatType}
+                  />
+                </div>
                 {!selectedTableId && (
                   <p className="text-xs text-muted-foreground text-center mt-2">
                     배치도에서 테이블을 선택해주세요
                   </p>
                 )}
-              </>
+              </div>
             )}
           </div>
 

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -17,6 +17,7 @@ import { getMockLayoutByRestaurantId } from "@/mock/seatLayout";
 import { getMockAvailableTableIds } from "@/mock/tableAvailability";
 import TableMap from "./TableMap";
 import { useConfirmClose } from "@/hooks/useConfirmClose";
+import { useDepositRate } from "@/hooks/useDepositRate";
 
 type Props = {
   open: boolean;
@@ -62,7 +63,7 @@ export default function ReservationModal({
   const [tablePref, setTablePref] = useState<TablePref>("split_ok");
   const [selectedTableId, setSelectedTableId] = useState<string | null>(null);
 
-  const depositRate = restaurant.paymentPolicy?.depositRate ?? 0.1;
+  const { rate: depositRate } = useDepositRate(restaurant.id);
   const paymentNotice =
     restaurant.paymentPolicy?.notice ??
     "예약 확정을 위해 예약금 결제가 필요합니다.";

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -16,6 +16,7 @@ import { startOfTodayInKst, toYmd } from "@/utils/date";
 import { getMockLayoutByRestaurantId } from "@/mock/seatLayout";
 import { getMockAvailableTableIds } from "@/mock/tableAvailability";
 import TableMap from "./TableMap";
+import { useConfirmClose } from "@/hooks/useConfirmClose";
 
 type Props = {
   open: boolean;
@@ -23,7 +24,7 @@ type Props = {
   restaurant: Restaurant;
   initialDraft?: ReservationDraft;
   onClickConfirm: (draft: ReservationDraft) => void;
-  onBack: () => void;
+  onClose: () => void;
 };
 
 const PEOPLE = [1, 2, 3, 4, 5, 6, 7, 8];
@@ -52,7 +53,7 @@ export default function ReservationModal({
   restaurant,
   initialDraft,
   onClickConfirm,
-  onBack,
+  onClose,
 }: Props) {
   const [people, setPeople] = useState<number>(2);
   const [date, setDate] = useState<Date | undefined>(undefined);
@@ -124,6 +125,8 @@ export default function ReservationModal({
     return SEATS.filter((s) => seatTypeExists.has(s));
   }, [layout, seatTypeExists]);
 
+  const handleRequestClose = useConfirmClose(onClose);
+
   if (!open) return null;
 
   return (
@@ -149,7 +152,7 @@ export default function ReservationModal({
           </div>
           <button
             type="button"
-            onClick={() => onOpenChange(false)}
+            onClick={handleRequestClose}
             className="p-2 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
             aria-label="모달 닫기"
           >

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -98,7 +98,7 @@ export default function ReservationModal({
     // 레스토랑 id가 있다고 가정함.
     //   return getMockLayoutByRestaurantId(restaurant.id ?? "r-1");
     // }, [restaurant]);
-    return getMockLayoutByRestaurantId("r-1"); //UI테스트 용으로 고정시켜 놓음.
+    return getMockLayoutByRestaurantId("1"); //UI테스트 용으로 고정시켜 놓음.
   }, []);
 
   const dateYmd = date ? toYmd(date) : "";
@@ -378,6 +378,7 @@ export default function ReservationModal({
 
           {/* 예약 확인 모달 이동 */}
           <Button
+            type="button"
             className="mt-5 text-md h-14 w-full rounded-lg cursor-pointer bg-blue-500 hover:bg-blue-600"
             disabled={!canSubmit}
             onClick={() => {

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -149,9 +149,9 @@ export default function ReservationModal({
           </div>
           <button
             type="button"
-            onClick={onBack}
+            onClick={() => onOpenChange(false)}
             className="p-2 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
-            aria-label="상세로 돌아가기"
+            aria-label="모달 닫기"
           >
             <X />
           </button>

--- a/src/components/reservation/ReservationModal.tsx
+++ b/src/components/reservation/ReservationModal.tsx
@@ -94,12 +94,8 @@ export default function ReservationModal({
 
   // 레이아웃 mock 넣음. (나중에 API로 교체예정)
   const layout: SeatLayout | null = useMemo(() => {
-    // 레스토랑 id없으면 name등 다른걸로 매핑하지말고 실제로 식당id가 있어야함.
-    // 레스토랑 id가 있다고 가정함.
-    //   return getMockLayoutByRestaurantId(restaurant.id ?? "r-1");
-    // }, [restaurant]);
-    return getMockLayoutByRestaurantId("1"); //UI테스트 용으로 고정시켜 놓음.
-  }, []);
+    return getMockLayoutByRestaurantId(restaurant.id ?? "1");
+  }, [restaurant.id]);
 
   const dateYmd = date ? toYmd(date) : "";
   const canQueryTables = !!layout && !!date && !!time;

--- a/src/components/restaurant/RestaurantDetailModal.tsx
+++ b/src/components/restaurant/RestaurantDetailModal.tsx
@@ -128,7 +128,7 @@ export default function RestaurantDetailModal({
                 type="button"
                 className="flex-1 bg-gray-100 text-black py-4 rounded-xl hover:bg-gray-200 transition-colors cursor-pointer"
                 onClick={() => {
-                  // Todo: 리뷰페이지로 이동
+                  window.alert("리뷰 기능은 추후 개발 예정입니다!");
                 }}
               >
                 테이블 리뷰 보기

--- a/src/hooks/useConfirmClose.ts
+++ b/src/hooks/useConfirmClose.ts
@@ -1,0 +1,8 @@
+export function useConfirmClose(onClose: () => void) {
+  return () => {
+    const ok = window.confirm(
+      "예약이 확정되지 않았습니다.\n예약화면을 벗어나시겠습니까?",
+    );
+    if (ok) onClose();
+  };
+}

--- a/src/mock/menus.ts
+++ b/src/mock/menus.ts
@@ -8,7 +8,7 @@ export const mockMenusByRestaurantId: Record<string, MenuItem[]> = {
       name: "김치찌개",
       category: "MAIN",
       description: "국내산 돼지고기와 숙성 김치로 만든 김치찌개",
-      imageUrl: undefined,
+      imageUrl: "/seatImg1.jpg",
       price: 9000,
       isSoldOut: false,
       isActive: true,

--- a/src/mock/seatLayout.ts
+++ b/src/mock/seatLayout.ts
@@ -3,7 +3,7 @@
 import type { SeatLayout } from "@/types/restaurant";
 
 export const MOCK_SEAT_LAYOUT_BY_RESTAURANT: Record<string, SeatLayout> = {
-  "r-1": {
+  "1": {
     gridCols: 8,
     gridRows: 6,
     tables: [

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -37,11 +37,6 @@ export default function SearchPage() {
     setReserveOpen(true);
   };
 
-  const backToDetail = () => {
-    setReserveOpen(false);
-    setDetailOpen(true);
-  };
-
   const goReserveMenu = (d: ReservationDraft) => {
     setDraft(d);
     setReserveOpen(false);
@@ -165,7 +160,7 @@ export default function SearchPage() {
           restaurant={selected}
           initialDraft={draft ?? undefined}
           onClickConfirm={goReserveMenu}
-          onBack={backToDetail} //X표시 누르면 상세페이지 모달로 이동
+          onClose={closeAll}
         />
       )}
       {/* 메뉴선택 모달 */}
@@ -179,6 +174,7 @@ export default function SearchPage() {
           restaurant={selected}
           onConfirm={goConfirm}
           onBack={backToReserve}
+          onClose={closeAll}
           draft={draft}
         />
       )}
@@ -205,7 +201,6 @@ export default function SearchPage() {
           onSuccess={() => {
             setCompleteOpen(true); //결제 성공 완료모달
           }}
-          onBack={() => setConfirmOpen(true)}
         />
       )}
       {/* 예약완료 페이지 모달 */}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -9,6 +9,7 @@ import ReservationModal from "@/components/reservation/ReservationModal";
 import ReservationConfirmMoodal from "@/components/reservation/ReservationConfirmModal";
 import ReservationCompleteModal from "@/components/reservation/ReservationCompleteModal";
 import PaymentModal from "@/components/reservation/PaymentModal";
+import ReservationMenuModal from "@/components/reservation/ReservationMenuModal";
 
 export default function SearchPage() {
   const [query, setQuery] = useState("");
@@ -16,6 +17,7 @@ export default function SearchPage() {
 
   const [detailOpen, setDetailOpen] = useState(false);
   const [reserveOpen, setReserveOpen] = useState(false);
+  const [reserveMenuOpen, setReserveMenuOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [draft, setDraft] = useState<ReservationDraft | null>(null);
   const [completeOpen, setCompleteOpen] = useState(false);
@@ -40,16 +42,24 @@ export default function SearchPage() {
     setDetailOpen(true);
   };
 
-  const goConfirm = (d: ReservationDraft) => {
+  const goReserveMenu = (d: ReservationDraft) => {
     setDraft(d);
     setReserveOpen(false);
-    setConfirmOpen(true);
-    setPaymentOpen(false);
+    setReserveMenuOpen(true);
   };
 
   const backToReserve = () => {
+    setReserveMenuOpen(false);
     setReserveOpen(true);
+  };
+  const goConfirm = (d: ReservationDraft) => {
+    setDraft(d);
+    setReserveMenuOpen(false);
+    setConfirmOpen(true);
+  };
+  const backToReserveMenu = () => {
     setConfirmOpen(false);
+    setReserveMenuOpen(true);
   };
 
   const goPayment = () => {
@@ -61,6 +71,7 @@ export default function SearchPage() {
     setDraft(null);
     setDetailOpen(false);
     setReserveOpen(false);
+    setReserveMenuOpen(false);
     setConfirmOpen(false);
     setSelected(null);
     setCompleteOpen(false);
@@ -153,8 +164,21 @@ export default function SearchPage() {
           }}
           restaurant={selected}
           initialDraft={draft ?? undefined}
-          onClickConfirm={goConfirm}
+          onClickConfirm={goReserveMenu}
           onBack={backToDetail} //X표시 누르면 상세페이지 모달로 이동
+        />
+      )}
+      {selected && draft && (
+        <ReservationMenuModal
+          open={reserveMenuOpen}
+          onOpenChange={(o: boolean) => {
+            setReserveMenuOpen(o);
+            if (!o) closeAll();
+          }}
+          restaurant={selected}
+          onConfirm={goConfirm}
+          onBack={backToReserve}
+          draft={draft}
         />
       )}
       {/* 예약확인 페이지 모달 */}
@@ -162,7 +186,7 @@ export default function SearchPage() {
         <ReservationConfirmMoodal
           open={confirmOpen}
           onClose={closeAll}
-          onBack={backToReserve} //X표시 누르면 예약페이지 모달로 이동
+          onBack={backToReserveMenu}
           onConfirm={goPayment}
           restaurant={selected}
           draft={draft}
@@ -170,7 +194,7 @@ export default function SearchPage() {
       )}
 
       {/* 결제 모달 */}
-      {selected && draft && (
+      {selected && draft && paymentOpen && (
         <PaymentModal
           open={paymentOpen}
           onClose={closeAll}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -168,6 +168,7 @@ export default function SearchPage() {
           onBack={backToDetail} //X표시 누르면 상세페이지 모달로 이동
         />
       )}
+      {/* 메뉴선택 모달 */}
       {selected && draft && (
         <ReservationMenuModal
           open={reserveMenuOpen}

--- a/src/pages/myPage/storePage.tsx
+++ b/src/pages/myPage/storePage.tsx
@@ -1,8 +1,13 @@
-
-import { Store, Calendar, Star, Plus, ChevronRight, BarChart3 } from "lucide-react";
-import { cn } from "../../lib/cn";
+import {
+  Store,
+  Calendar,
+  Star,
+  Plus,
+  ChevronRight,
+  BarChart3,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 import { Link } from "react-router-dom";
-
 
 export default function StorePage() {
   const stats = [
@@ -73,9 +78,10 @@ export default function StorePage() {
             등록한 식당을 관리하고 대시보드로 이동하세요
           </p>
         </div>
-        <Link 
-          to="/mypage/store/register" 
-          className="cursor-pointer flex items-center gap-2 rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600 transition-colors">
+        <Link
+          to="/mypage/store/register"
+          className="cursor-pointer flex items-center gap-2 rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600 transition-colors"
+        >
           <Plus size={18} /> 새 가게 등록
         </Link>
       </div>


### PR DESCRIPTION
## 💡 개요
고객 예약 flow에서 메뉴 선택 모달 UI를 추가하고, 선택한 메뉴의 총액과 그에 예약금률을 적용하여 예약금이 보여지도록 구현

## 🔢 관련 이슈 링크
- Closes #38 

## 💻 작업내용
- SearchPage.tsx에서 예약 flow에 메뉴 선택 모달 단계 추가
- 메뉴 카테고리별(메인/사이드/음료) 리스트 출력, 수량 증감버튼, 품절 상태 UI및 비활성 처리(ResevationMenuModal.tsx)
- 선택한 메뉴 상태를 draft에 반영해서  예약확인 단계와 결제 단계로 전달
- 메뉴 총액과 예약금 계산을 모달 하단에 요약
- 예약 확인 모달에서 예약금률이 적용된 값으로 표시되도록 수정

## 📌 변경사항PR
- [x] FEAT: 새로운 기능 추가
- [ ] FIX: 버그/오류 수정
- [x] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [x] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [x] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
N/A

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 예약 흐름에 메뉴 선택 단계 추가(예약 → 메뉴 → 확인 → 결제)
  * 닫기 시 확인을 요구하는 통합 종료 확인 흐름 추가(뒤로가기 동작 제거)

* **UI 개선**
  * 선택한 메뉴 기반 총액 및 비율 기반 예치금 자동 계산·표시(총액·비율 별도 노출)
  * 메뉴 목록에 사진·설명·품절 표시 및 수량 조절(0–20) UI 제공
  * 예약 확인에 결제 안내문 노출·날짜 선택 동작 개선·테이블 뷰 가로스크롤 보강

* **기타**
  * 목업 이미지/레이아웃 키 및 문구 소소 수정; 리뷰 버튼에 안내 알림 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->