### PR TITLE
feat : 카카오맵 연동 및 검색 결과 마커 자동으로 이동되도록 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 VITE_API_URL=https://api.example.com
+
+VITE_KAKAO_JS_KEY=

--- a/src/api/adapters/store.adapter.ts
+++ b/src/api/adapters/store.adapter.ts
@@ -1,0 +1,54 @@
+import type {
+  BreakTime,
+  RestaurantDetail,
+  RestaurantSummary,
+} from "@/types/store";
+import type {
+  StoreDetailDataDTO,
+  StoreSearchItemDTO,
+} from "@/api/dto/store.dto";
+
+export function toRestaurantSummary(
+  dto: StoreSearchItemDTO,
+): RestaurantSummary {
+  return {
+    id: dto.storeId,
+    name: dto.name,
+    address: dto.address,
+    category: dto.category,
+    rating: dto.rating,
+    reviewCount: dto.reviewCount,
+    distanceKm: dto.distance,
+    thumbnailUrl: dto.mainImageUrl,
+    isOpenNow: dto.isOpenNow,
+  };
+}
+
+export function toRestaurantDetail(dto: StoreDetailDataDTO): RestaurantDetail {
+  const breakTime = toBreakTime(dto.breakStartTime, dto.breakEndTime);
+
+  return {
+    id: dto.storeId,
+    name: dto.storeName,
+    description: dto.description,
+    address: dto.address,
+    phone: dto.phone,
+    category: dto.category,
+    rating: dto.rating,
+    reviewCount: dto.reviewCount,
+    depositAmount: dto.depositAmount,
+    mainImageUrl: dto.mainImageUrl,
+    tableImageUrls: dto.tableImageUrls ?? [],
+    businessHours: dto.businessHours ?? [],
+    breakTime,
+    isOpenNow: dto.isOpenNow,
+  };
+}
+
+function toBreakTime(
+  start?: string | null,
+  end?: string | null,
+): BreakTime | undefined {
+  if (!start || !end) return undefined;
+  return { start, end };
+}

--- a/src/api/adapters/store.adapter.ts
+++ b/src/api/adapters/store.adapter.ts
@@ -21,6 +21,7 @@ export function toRestaurantSummary(
     distanceKm: dto.distance,
     thumbnailUrl: dto.mainImageUrl,
     isOpenNow: dto.isOpenNow,
+    location: { lat: dto.latitude, lng: dto.longitude },
   };
 }
 

--- a/src/api/dto/store.dto.ts
+++ b/src/api/dto/store.dto.ts
@@ -1,7 +1,7 @@
 export type ApiResponseDTO<T> = {
   success: boolean;
   code: string;
-  date: T;
+  data: T;
   message: string;
 };
 
@@ -22,6 +22,8 @@ export type StoreSearchItemDTO = {
   distance: number;
   mainImageUrl: string;
   isOpenNow: boolean;
+  latitude: number;
+  longitude: number;
 };
 
 export type PaginationDTO = {

--- a/src/api/dto/store.dto.ts
+++ b/src/api/dto/store.dto.ts
@@ -1,0 +1,76 @@
+export type ApiResponseDTO<T> = {
+  success: boolean;
+  code: string;
+  date: T;
+  message: string;
+};
+
+export type CategoryDTO =
+  | "KOREAN"
+  | "CHINESE"
+  | "JAPANESE"
+  | "WESTERN"
+  | "CAFE";
+
+export type StoreSearchItemDTO = {
+  storeId: string;
+  name: string;
+  address: string;
+  category: CategoryDTO;
+  rating: number;
+  reviewCount: number;
+  distance: number;
+  mainImageUrl: string;
+  isOpenNow: boolean;
+};
+
+export type PaginationDTO = {
+  currentPage: number;
+  totalPages: number;
+  totalCount: number;
+  isFirst: boolean;
+  isLast: boolean;
+};
+
+export type StoreSearchDataDTO = {
+  stores: StoreSearchItemDTO[];
+  pagination: PaginationDTO;
+};
+
+export type StoreSearchResponseDTO = ApiResponseDTO<StoreSearchDataDTO>;
+
+export type DayDTO =
+  | "MONDAY"
+  | "TUESDAY"
+  | "WEDNESDAY"
+  | "THURSDAY"
+  | "FRIDAY"
+  | "SATURDAY"
+  | "SUNDAY";
+
+export type BusinessHourDTO = {
+  day: DayDTO;
+  openTime: string | null;
+  closeTime: string | null;
+  isClosed: boolean;
+};
+
+export type StoreDetailDataDTO = {
+  storeId: string;
+  storeName: string;
+  description: string;
+  address: string;
+  phone: string;
+  category: CategoryDTO;
+  rating: number;
+  reviewCount: number;
+  depositAmount: number;
+  mainImageUrl?: string;
+  tableImageUrls: string[];
+  businessHours: BusinessHourDTO[];
+  breakStartTime?: string | null;
+  breakEndTime?: string | null;
+  isOpenNow?: boolean;
+};
+
+export type StoreDetailResponseDTO = ApiResponseDTO<StoreDetailDataDTO>;

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -40,6 +40,7 @@ export default function KakaoMap({
   );
 
   const [sdkReady, setSdkReady] = useState(!!window.kakao?.maps);
+  const [sdkError, setSdkError] = useState<string | null>(null);
 
   //1. 지도 최초 1회 생성
   useEffect(() => {
@@ -63,6 +64,7 @@ export default function KakaoMap({
         infoRef.current = new kakao.maps.InfoWindow({ zIndex: 2 });
       } catch (e) {
         console.error(e);
+        setSdkError("카카오맵 로딩에 실패했습니다.");
       }
     };
     init();

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -39,7 +39,7 @@ export default function KakaoMap({
     [markers],
   );
 
-  const [sdkReady, setSdkReady] = useState(!!window.kakao?.map);
+  const [sdkReady, setSdkReady] = useState(!!window.kakao?.maps);
 
   //1. 지도 최초 1회 생성
   useEffect(() => {
@@ -185,7 +185,7 @@ export default function KakaoMap({
         "relative w-full h-125 bg-gray-100 rounded-xl overflow-hidden"
       }
     >
-      {!setSdkReady ? (
+      {!sdkReady ? (
         <div className="absolute inset-0 flex items-center justify-center text-gray-500 text-sm">
           카카오맵 로딩 중..
         </div>

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -186,7 +186,11 @@ export default function KakaoMap({
       }
     >
       {!sdkReady ? (
-        <div className="absolute inset-0 flex items-center justify-center text-gray-500 text-sm">
+        <div
+          className="absolute inset-0 flex items-center justify-center text-gray-500 text-sm"
+          role="status"
+          aria-live="polite"
+        >
           카카오맵 로딩 중..
         </div>
       ) : null}

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,0 +1,126 @@
+import { loadKakaoMapSdk } from "@/lib/kakao";
+import type { RestaurantSummary } from "@/types/store";
+import { useEffect, useMemo, useRef } from "react";
+
+type LatLng = { lat: number; lng: number };
+
+type Props = {
+  center: LatLng;
+  markers: RestaurantSummary[];
+  selectedId?: string | null;
+  onSelectMarker?: (store: RestaurantSummary) => void;
+  className?: string;
+};
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+export default function KakaoMap({
+  center,
+  markers,
+  selectedId,
+  onSelectMarker,
+  className,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<any>(null);
+  const markersRef = useRef<any[]>([]);
+  const infoRef = useRef<any>(null);
+
+  const safeMarkers = useMemo(
+    () => markers.filter((m) => !!m.location),
+    [markers],
+  );
+
+  //1. 지도 최초 1회 생성
+  useEffect(() => {
+    let cancelled = false;
+
+    const init = async () => {
+      try {
+        await loadKakaoMapSdk();
+        if (cancelled) return;
+        if (!containerRef.current) return;
+
+        const kakao = window.kakao;
+        if (mapRef.current) return;
+
+        const options = {
+          center: new kakao.maps.LatLng(center.lat, center.lng),
+          level: 4,
+        };
+        mapRef.current = new kakao.maps.Map(containerRef.current, options);
+        infoRef.current = new kakao.maps.InfoWindow({ zIndex: 2 });
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    init();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  //2. 센터바뀌면 지도 중심 이동
+  useEffect(() => {
+    const kakao = window.kakao;
+    if (!kakao?.maps) return;
+    if (!mapRef.current) return;
+
+    const next = new kakao.maps.LatLng(center.lat, center.lng);
+    mapRef.current.setCenter(next);
+  }, [center.lat, center.lng]);
+
+  //3. 마커 바뀌면 마커 재생성
+  useEffect(() => {
+    const kakao = window.kakao;
+    if (!kakao?.maps) return;
+    if (!mapRef.current) return;
+
+    markersRef.current.forEach((mk) => mk.setMap(null));
+    markersRef.current = [];
+
+    safeMarkers.forEach((store) => {
+      const loc = store.location;
+      const pos = new kakao.maps.LatLng(loc.lat, loc.lng);
+
+      const isSelected = selectedId && store.id === selectedId;
+
+      const marker = new kakao.maps.Marker({
+        map: mapRef.current,
+        position: pos,
+        clickable: true,
+        zIndex: isSelected ? 10 : 1,
+      });
+
+      kakao.maps.event.addListener(marker, "click", () => {
+        if (infoRef.current) {
+          infoRef.current.setContent(
+            `<div style="padding:6px 8px;font-size:12px;line-height:1.2;">${store.name}</div>`,
+          );
+          infoRef.current.open(mapRef.current, marker);
+        }
+        onSelectMarker?.(store);
+      });
+      markersRef.current.push(marker);
+    });
+  }, [safeMarkers, selectedId, onSelectMarker]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={
+        className ??
+        "relative w-full h-125 bg-gray-100 rounded-xl overflow-hidden"
+      }
+    >
+      {!window.kakao?.maps ? (
+        <div className="absolute inset-0 flex items-center justify-center text-gray-500 text-sm">
+          카카오맵 로딩 중..
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,6 +1,6 @@
 import { loadKakaoMapSdk } from "@/lib/kakao";
 import type { RestaurantSummary } from "@/types/store";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type LatLng = { lat: number; lng: number };
 
@@ -39,6 +39,8 @@ export default function KakaoMap({
     [markers],
   );
 
+  const [sdkReady, setSdkReady] = useState(!!window.kakao?.map);
+
   //1. 지도 최초 1회 생성
   useEffect(() => {
     let cancelled = false;
@@ -47,6 +49,7 @@ export default function KakaoMap({
       try {
         await loadKakaoMapSdk();
         if (cancelled) return;
+        setSdkReady(true);
         if (!containerRef.current) return;
 
         const kakao = window.kakao;
@@ -182,7 +185,7 @@ export default function KakaoMap({
         "relative w-full h-125 bg-gray-100 rounded-xl overflow-hidden"
       }
     >
-      {!window.kakao?.maps ? (
+      {!setSdkReady ? (
         <div className="absolute inset-0 flex items-center justify-center text-gray-500 text-sm">
           카카오맵 로딩 중..
         </div>

--- a/src/components/restaurant/RestaurantCard.tsx
+++ b/src/components/restaurant/RestaurantCard.tsx
@@ -1,8 +1,8 @@
-import type { Restaurant } from "@/types/restaurant";
+import { categoryLabel, type RestaurantSummary } from "@/types/store";
 import { Star } from "lucide-react";
 
 type Props = {
-  restaurant: Restaurant;
+  restaurant: RestaurantSummary;
   onClick: () => void;
 };
 
@@ -19,12 +19,11 @@ export default function RestaurantCard({ restaurant, onClick }: Props) {
             {restaurant.name}
           </p>
           <p className="mt-1 text-sm text-gray-500 truncate">
-            {restaurant.category ?? "카테고리 없음"} • {restaurant.address}
+            {categoryLabel[restaurant.category]} • {restaurant.address}
           </p>
         </div>
 
         <span className="flex items-center gap-2 text-sm text-gray-500 shrink-0 self-center">
-          {" "}
           <Star className="size-5 text-yellow-500 fill-yellow-500" />
           {restaurant.rating.toFixed(1)}
         </span>

--- a/src/components/restaurant/RestaurantDetailModal.tsx
+++ b/src/components/restaurant/RestaurantDetailModal.tsx
@@ -71,6 +71,7 @@ export default function RestaurantDetailModal({
         <button
           type="button"
           className="absolute inset-0 bg-black/40"
+          aria-label="모달 닫기"
           onClick={() => onOpenChange(false)}
         />
         <div className="relative z-10 w-[92vw] max-w-3xl rounded-2xl bg-white shadow-xl p-6">
@@ -78,6 +79,7 @@ export default function RestaurantDetailModal({
             <p className="text-lg">상세 정보 불러오는 중..</p>
             <button
               type="button"
+              aria-label="모달 닫기"
               onClick={() => onOpenChange(false)}
               className="p-2 rounded-lg hover:bg-gray-100"
             >
@@ -97,7 +99,7 @@ export default function RestaurantDetailModal({
         className="fixed inset-0 z-50 flex items-center justify-center p-4"
         role="dialog"
         aria-modal="true"
-        aria-label="식당 상세 로딩"
+        aria-label="식당 상세 오류"
       >
         <button
           type="button"

--- a/src/components/restaurant/RestaurantDetailModal.tsx
+++ b/src/components/restaurant/RestaurantDetailModal.tsx
@@ -4,7 +4,10 @@ import { Clock, Star, X } from "lucide-react";
 type Props = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  restaurant: RestaurantDetail;
+  status: "idle" | "loading" | "success" | "error";
+  restaurant?: RestaurantDetail | null;
+  errorMessage?: string;
+  onRetry?: () => void;
   onClickReserve: () => void;
 };
 
@@ -49,10 +52,96 @@ function formatBusinessHours(r: RestaurantDetail) {
 export default function RestaurantDetailModal({
   open,
   onOpenChange,
+  status,
   restaurant,
+  errorMessage,
+  onRetry,
   onClickReserve,
 }: Props) {
   if (!open) return null;
+
+  if (status === "idle" || status === "loading") {
+    return (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-label="식당 상세 로딩"
+      >
+        <button
+          type="button"
+          className="absolute inset-0 bg-black/40"
+          onClick={() => onOpenChange(false)}
+        />
+        <div className="relative z-10 w-[92vw] max-w-3xl rounded-2xl bg-white shadow-xl p-6">
+          <div className="flex items-center justify-between">
+            <p className="text-lg">상세 정보 불러오는 중..</p>
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="p-2 rounded-lg hover:bg-gray-100"
+            >
+              <X />
+            </button>
+          </div>
+          <div className="mt-6 text-sm text-gray-500">
+            잠시만 기다려 주세요..
+          </div>
+        </div>
+      </div>
+    );
+  }
+  if (status === "error") {
+    return (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-label="식당 상세 로딩"
+      >
+        <button
+          type="button"
+          className="absolute inset-0 bg-black/40"
+          onClick={() => onOpenChange(false)}
+        />
+        <div className="relative z-10 w-[92vw] max-w-3xl rounded-2xl bg-white shadow-xl p-6">
+          <div className="flex items-center justify-between">
+            <p className="text-lg">상세 정보를 불러오지 못했어요</p>
+            <button
+              type="button"
+              className="p-2 rounded-lg hover:bg-gray-100"
+              onClick={() => onOpenChange(false)}
+            >
+              <X />
+            </button>
+          </div>
+          <p className="mt-4 text-sm text-gray-600">
+            {errorMessage ?? "잠시 후 다시 시도해주세요"}
+          </p>
+          <div className="mt-6 flex gap-3">
+            <button
+              type="button"
+              className="flex-1 bg-gray-100 py-3 rounded-xl"
+              onClick={() => onOpenChange(false)}
+            >
+              닫기
+            </button>
+            {onRetry ? (
+              <button
+                type="button"
+                className="flex-1 bg-blue-500 text-white py-3 rounded-xl"
+                onClick={onRetry}
+              >
+                다시 시도
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    );
+  }
+  if (status !== "success") return null;
+  if (!restaurant) return null;
   const { lines: hourLines, breakLine } = formatBusinessHours(restaurant);
   return (
     <div

--- a/src/components/restaurant/RestaurantList.tsx
+++ b/src/components/restaurant/RestaurantList.tsx
@@ -1,9 +1,9 @@
+import type { RestaurantSummary } from "@/types/store";
 import RestaurantCard from "./RestaurantCard";
-import type { Restaurant } from "@/types/restaurant";
 
 type Props = {
-  restaurants: Restaurant[];
-  onSelect: (restaurant: Restaurant) => void;
+  restaurants: RestaurantSummary[];
+  onSelect: (restaurant: RestaurantSummary) => void;
 };
 
 export default function RestaurantList({ restaurants, onSelect }: Props) {

--- a/src/lib/kakao.ts
+++ b/src/lib/kakao.ts
@@ -25,16 +25,20 @@ export function loadKakaoMapSdk(): Promise<void> {
     script.type = "text/javascript";
     script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${key}&autoload=false&libraries=services`;
 
+    const fail = (err: Error) => {
+      loadingPromise = null;
+      reject(err);
+    };
+
     script.onload = () => {
       if (!window.kakao?.maps?.load) {
-        reject(new Error("Kakao Maps SDK 로드에 실패했습니다."));
+        fail(new Error("Kakao Maps SDK 로드에 실패했습니다."));
         return;
       }
       window.kakao.maps.load(() => resolve());
     };
 
-    script.onerror = () =>
-      reject(new Error("Kakao Maps SDK 스크립트 로드 실패"));
+    script.onerror = () => fail(new Error("Kakao Maps SDK 스크립트 로드 실패"));
     document.head.appendChild(script);
   });
 

--- a/src/lib/kakao.ts
+++ b/src/lib/kakao.ts
@@ -1,0 +1,42 @@
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+let loadingPromise: Promise<void> | null = null;
+
+export function loadKakaoMapSdk(): Promise<void> {
+  // 이미 로드됨
+  if (window.kakao?.maps) return Promise.resolve();
+
+  if (loadingPromise) return loadingPromise;
+
+  const key = import.meta.env.VITE_KAKAO_JS_KEY as string | undefined;
+  if (!key) {
+    return Promise.reject(
+      new Error("VITE_KAKAO_JS_KEY가 .env에 없습니다. (.env 확인)"),
+    );
+  }
+
+  loadingPromise = new Promise<void>((resolve, reject) => {
+    const script = document.createElement("script");
+    script.async = true;
+    script.type = "text/javascript";
+    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${key}&autoload=false&libraries=services`;
+
+    script.onload = () => {
+      if (!window.kakao?.maps?.load) {
+        reject(new Error("Kakao Maps SDK 로드에 실패했습니다."));
+        return;
+      }
+      window.kakao.maps.load(() => resolve());
+    };
+
+    script.onerror = () =>
+      reject(new Error("Kakao Maps SDK 스크립트 로드 실패"));
+    document.head.appendChild(script);
+  });
+
+  return loadingPromise;
+}

--- a/src/mock/store.api.mock.ts
+++ b/src/mock/store.api.mock.ts
@@ -1,0 +1,76 @@
+import type { RestaurantSummary } from "@/types/store";
+import { MOCK_STORE_SEARCH } from "@/mock/stores.search.mock";
+
+export type StoreSearchParams = {
+  lat: number;
+  lng: number;
+  keyword?: string;
+  radiusKm?: number;
+  sort?: "distance" | "rating";
+
+  // API 붙이면 여기 확장하기
+  // TODO: params.lat/lng 기반 거리 필터/정렬 추가 예정
+  // category?: Category;
+  // page?: number;
+  // limit?: number;
+  // sido?: string;
+  // sigungu?: string;
+  // bname?: string;
+};
+
+export async function searchMockStores(
+  params: StoreSearchParams,
+): Promise<RestaurantSummary[]> {
+  await new Promise((r) => setTimeout(r, 500));
+
+  const q = (params.keyword ?? "").trim().toLowerCase();
+
+  if (!q) return [];
+
+  const center = { lat: params.lat, lng: params.lng };
+  const radiusKm = params.radiusKm ?? 5;
+  const sort = params.sort ?? "distance";
+
+  const matched = MOCK_STORE_SEARCH.filter((r) => {
+    const name = r.name.toLowerCase();
+    const category = r.category.toLowerCase();
+    const address = r.address.toLowerCase();
+    return name.includes(q) || category.includes(q) || address.includes(q);
+  });
+  const withDistance = matched
+    .map((r) => {
+      const distanceKm = haversineKm(center, r.location);
+      return { r, distanceKm };
+    })
+    .filter(({ distanceKm }) => distanceKm <= radiusKm);
+
+  withDistance.sort((a, b) => {
+    if (sort === "rating") return b.r.rating - a.r.rating;
+    return a.distanceKm - b.distanceKm;
+  });
+
+  return withDistance.map(({ r }) => r);
+}
+
+export function toRad(deg: number) {
+  return (deg * Math.PI) / 180;
+}
+export function haversineKm(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number },
+) {
+  const R = 6371;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+
+  const sinDLat = Math.sin(dLat / 2);
+  const sinDLng = Math.sin(dLng / 2);
+
+  const x =
+    sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLng * sinDLng;
+  const c = 2 * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
+  return R * c;
+}

--- a/src/mock/store.api.mock.ts
+++ b/src/mock/store.api.mock.ts
@@ -49,7 +49,7 @@ export async function searchMockStores(
     return a.distanceKm - b.distanceKm;
   });
 
-  return withDistance.map(({ r }) => r);
+  return withDistance.map(({ r, distanceKm }) => ({ ...r, distanceKm }));
 }
 
 export function toRad(deg: number) {

--- a/src/mock/stores.detail.mock.ts
+++ b/src/mock/stores.detail.mock.ts
@@ -1,0 +1,147 @@
+import type { RestaurantDetail } from "@/types/store";
+
+export const MOCK_STORE_DETAIL_BY_ID: Record<string, RestaurantDetail> = {
+  "1": {
+    id: "1",
+    name: "모던 한식당",
+    category: "KOREAN",
+    rating: 4.7,
+    reviewCount: 328,
+    address: "서울특별시 강남구 테헤란로 123",
+    phone: "02-1111-1111",
+    description:
+      "전통 한식을 모던하게 재해석한 프리미엄 한식 레스토랑입니다. 신선한 재료로 정성껏 준비한 요리를 맛보실 수 있습니다",
+    depositAmount: 3000,
+    mainImageUrl: "/modernKoreaRestaurant.jpg",
+    tableImageUrls: ["/seatImg1.jpg", "/seatImg2.jpg"],
+    businessHours: [
+      { day: "MONDAY", openTime: "11:00", closeTime: "22:00", isClosed: false },
+      {
+        day: "TUESDAY",
+        openTime: "11:00",
+        closeTime: "22:00",
+        isClosed: false,
+      },
+      {
+        day: "WEDNESDAY",
+        openTime: "11:00",
+        closeTime: "22:00",
+        isClosed: false,
+      },
+      {
+        day: "THURSDAY",
+        openTime: "11:00",
+        closeTime: "22:00",
+        isClosed: false,
+      },
+      { day: "FRIDAY", openTime: "11:00", closeTime: "22:00", isClosed: false },
+      {
+        day: "SATURDAY",
+        openTime: "11:00",
+        closeTime: "22:00",
+        isClosed: false,
+      },
+      { day: "SUNDAY", openTime: "11:00", closeTime: "22:00", isClosed: false },
+    ],
+    breakTime: { start: "15:00", end: "17:00" },
+    isOpenNow: true,
+    location: { lat: 37.498, lng: 127.0276 },
+  },
+  "2": {
+    id: "2",
+    name: "이탈리아 트라토리아",
+    category: "WESTERN",
+    rating: 4.5,
+    reviewCount: 215,
+    address: "서울특별시 종로구 인사동길 45",
+    phone: "02-2222-2222",
+    description:
+      "전통 이탈리아 가정식을 선보이는 아늑한 레스토랑입니다. 직접 만든 파스타와 피자를 즐기실 수 있습니다.",
+    depositAmount: 5000,
+    mainImageUrl: "/ItalyTrattoria.jpg",
+    tableImageUrls: ["/seatImg1.jpg", "/seatImg2.jpg"],
+    businessHours: [
+      { day: "MONDAY", openTime: "12:00", closeTime: "22:00", isClosed: false },
+      {
+        day: "TUESDAY",
+        openTime: "12:00",
+        closeTime: "22:00",
+        isClosed: false,
+      },
+      {
+        day: "WEDNESDAY",
+        openTime: "12:00",
+        closeTime: "22:00",
+        isClosed: false,
+      },
+      {
+        day: "THURSDAY",
+        openTime: "12:00",
+        closeTime: "22:00",
+        isClosed: false,
+      },
+      { day: "FRIDAY", openTime: "12:00", closeTime: "22:00", isClosed: false },
+      {
+        day: "SATURDAY",
+        openTime: "12:00",
+        closeTime: "22:00",
+        isClosed: false,
+      },
+      { day: "SUNDAY", openTime: "12:00", closeTime: "22:00", isClosed: false },
+    ],
+    isOpenNow: false,
+    location: { lat: 37.574, lng: 126.985 },
+  },
+  "3": {
+    id: "3",
+    name: "스카이뷰 레스토랑",
+    category: "WESTERN",
+    rating: 4.8,
+    reviewCount: 452,
+    address: "서울특별시 마포구 월드컵북로 56",
+    phone: "02-3333-3333",
+    description:
+      "한강 뷰를 감상하며 식사할 수 있는 프리미엄 다이닝 레스토랑입니다. 로맨틱한 분위기와 훌륭한 전망을 자랑합니다.",
+    depositAmount: 7000,
+    mainImageUrl: "/seatImg1.jpg",
+    tableImageUrls: ["/seatImg1.jpg", "/seatImg2.jpg"],
+    businessHours: [
+      { day: "MONDAY", openTime: "10:00", closeTime: "20:00", isClosed: false },
+      {
+        day: "TUESDAY",
+        openTime: "10:00",
+        closeTime: "20:00",
+        isClosed: false,
+      },
+      {
+        day: "WEDNESDAY",
+        openTime: "10:00",
+        closeTime: "20:00",
+        isClosed: false,
+      },
+      {
+        day: "THURSDAY",
+        openTime: "10:00",
+        closeTime: "20:00",
+        isClosed: false,
+      },
+      { day: "FRIDAY", openTime: "10:00", closeTime: "22:00", isClosed: false },
+      {
+        day: "SATURDAY",
+        openTime: "10:00",
+        closeTime: "22:00",
+        isClosed: false,
+      },
+      { day: "SUNDAY", openTime: "10:00", closeTime: "20:00", isClosed: false },
+    ],
+    breakTime: { start: "14:00", end: "17:00" },
+    isOpenNow: true,
+    location: { lat: 37.5695, lng: 126.8997 },
+  },
+};
+
+export function getMockStoreDetail(
+  storeId: string,
+): RestaurantDetail | undefined {
+  return MOCK_STORE_DETAIL_BY_ID[storeId];
+}

--- a/src/mock/stores.detail.mock.ts
+++ b/src/mock/stores.detail.mock.ts
@@ -90,7 +90,7 @@ export const MOCK_STORE_DETAIL_BY_ID: Record<string, RestaurantDetail> = {
       { day: "SUNDAY", openTime: "12:00", closeTime: "22:00", isClosed: false },
     ],
     isOpenNow: false,
-    location: { lat: 37.574, lng: 126.985 },
+    location: { lat: 37.574, lng: 126.984 },
   },
   "3": {
     id: "3",

--- a/src/mock/stores.search.mock.ts
+++ b/src/mock/stores.search.mock.ts
@@ -1,0 +1,40 @@
+import type { RestaurantSummary } from "@/types/store";
+
+export const MOCK_STORE_SEARCH: RestaurantSummary[] = [
+  {
+    id: "1",
+    name: "모던 한식당",
+    category: "KOREAN",
+    rating: 4.7,
+    reviewCount: 328,
+    address: "서울특별시 강남구 테헤란로 123",
+    thumbnailUrl: "/modernKoreaRestaurant.jpg",
+    distanceKm: 3.2,
+    isOpenNow: true,
+    location: { lat: 37.498, lng: 127.0276 },
+  },
+  {
+    id: "2",
+    name: "이탈리아 트라토리아",
+    category: "WESTERN",
+    rating: 4.5,
+    reviewCount: 215,
+    address: "서울특별시 종로구 인사동길 45",
+    thumbnailUrl: "/ItalyTrattoria.jpg",
+    distanceKm: 1.1,
+    isOpenNow: false,
+    location: { lat: 37.574, lng: 126.985 },
+  },
+  {
+    id: "3",
+    name: "스카이뷰 레스토랑",
+    category: "WESTERN",
+    rating: 4.8,
+    reviewCount: 452,
+    address: "서울특별시 마포구 월드컵북로 56",
+    thumbnailUrl: "/seatImg1.jpg",
+    distanceKm: 5.4,
+    isOpenNow: true,
+    location: { lat: 37.5695, lng: 126.8997 },
+  },
+];

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Search } from "lucide-react";
 import RestaurantList from "@/components/restaurant/RestaurantList";
 import { type ReservationDraft, type Restaurant } from "@/types/restaurant";
@@ -32,6 +32,8 @@ export default function SearchPage() {
   const [detailData, setDetailData] = useState<RestaurantDetail | null>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
 
+  const detailRequestIdRef = useRef(0);
+
   const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(
     null,
   );
@@ -57,6 +59,7 @@ export default function SearchPage() {
 
   const openDetail = async (restaurant: RestaurantSummary) => {
     const storeId = restaurant.id;
+    const requestId = ++detailRequestIdRef.current;
 
     setSelectedStoreId(storeId);
     setDetailOpen(true);
@@ -68,6 +71,7 @@ export default function SearchPage() {
     setReserveOpen(false);
     try {
       const detail = await fetchStoreDetailMock(storeId);
+      if (requestId !== detailRequestIdRef.current) return;
       setDetailData(detail);
       setDetailStatus("success");
     } catch (e) {
@@ -80,10 +84,12 @@ export default function SearchPage() {
 
   const retryDetail = async () => {
     if (!selectedStoreId) return;
+    const requestId = ++detailRequestIdRef.current;
     setDetailStatus("loading");
     setDetailError(null);
     try {
       const detail = await fetchStoreDetailMock(selectedStoreId);
+      if (requestId !== detailRequestIdRef.current) return;
       setDetailData(detail);
       setDetailStatus("success");
     } catch (e) {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -145,15 +145,15 @@ export default function SearchPage() {
     setConfirmOpen(false);
     setPaymentOpen(false);
     setCompleteOpen(false);
-    setDetailStatus("idle");
-    setDetailData(null);
-    setDetailError(null);
-    setDraft(null);
   };
 
   const resetAll = () => {
     closeModalsOnly();
+    setDraft(null);
     setSelectedStoreId(null);
+    setDetailStatus("idle");
+    setDetailData(null);
+    setDetailError(null);
     setResults([]);
     setSearchError(null);
     setHasSearched(false);
@@ -205,6 +205,21 @@ export default function SearchPage() {
         sort: "distance",
       });
       setResults(items);
+
+      if (items.length === 1 && items[0].location) {
+        setMapCenter({
+          lat: items[0].location.lat,
+          lng: items[0].location.lng,
+        });
+        setSelectedStoreId(items[0].id);
+      } else if (items.length > 0) {
+        const first = items.find((x) => x.location);
+        if (first?.location) {
+          setMapCenter({ lat: first.location.lat, lng: first.location.lng });
+        }
+      } else {
+        setMapCenter({ lat: c.lat, lng: c.lng });
+      }
     } catch (e) {
       const msg = e instanceof Error ? e.message : "검색에 실패했어요";
       setSearchError(msg);

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -138,22 +138,28 @@ export default function SearchPage() {
     setPaymentOpen(true);
   };
 
-  const closeAll = () => {
-    setDraft(null);
+  const closeModalsOnly = () => {
     setDetailOpen(false);
     setReserveOpen(false);
     setReserveMenuOpen(false);
     setConfirmOpen(false);
-    setSelectedStoreId(null);
-    setCompleteOpen(false);
     setPaymentOpen(false);
+    setCompleteOpen(false);
     setDetailStatus("idle");
     setDetailData(null);
     setDetailError(null);
+    setDraft(null);
+  };
+
+  const resetAll = () => {
+    closeModalsOnly();
+    setSelectedStoreId(null);
     setResults([]);
     setSearchError(null);
     setHasSearched(false);
     setMapCenter(FALLBACK_COORDS);
+    setCoords(null);
+    setQuery("");
   };
 
   function getCoords(): Promise<{ lat: number; lng: number }> {
@@ -195,7 +201,7 @@ export default function SearchPage() {
         lat: c.lat,
         lng: c.lng,
         keyword,
-        radiusKm: 3,
+        radiusKm: 50,
         sort: "distance",
       });
       setResults(items);
@@ -232,23 +238,14 @@ export default function SearchPage() {
         </div>
       </div>
 
-      {/* 지도는 API연동을 위해 지금 비워둠 */}
-      {/* <div className="relative w-full h-125 bg-gray-100 rounded-xl overflow-hidden">
-        <div className="absolute inset-0 bg-linear-to-br from-gray-200 to-gray-300">
-          <div className="absolute inset-0 flex items-center justify-center text-gray-400">
-            <div className="text-center">
-              <p>카카오맵 API 연동 영역</p>
-            </div>
-          </div>
-        </div>
-      </div> */}
-
       {/* 카카오맵 */}
       <KakaoMap
         center={mapCenter}
         markers={results}
         selectedId={selectedStoreId}
         onSelectMarker={handleSelectStore}
+        defaultLevel={4}
+        selectedLevel={3}
       />
 
       <div className="mt-6 w-full max-w-2xl mx-auto">
@@ -266,7 +263,7 @@ export default function SearchPage() {
           onOpenChange={(o: boolean) => {
             setDetailOpen(o);
             if (!o) {
-              closeAll();
+              closeModalsOnly();
             }
           }}
           status={detailStatus}
@@ -282,12 +279,12 @@ export default function SearchPage() {
           open={reserveOpen}
           onOpenChange={(o: boolean) => {
             setReserveOpen(o);
-            if (!o) closeAll();
+            if (!o) closeModalsOnly();
           }}
           restaurant={selectedLegacy}
           initialDraft={draft ?? undefined}
           onClickConfirm={goReserveMenu}
-          onClose={closeAll}
+          onClose={closeModalsOnly}
         />
       )}
       {/* 메뉴선택 모달 */}
@@ -296,12 +293,12 @@ export default function SearchPage() {
           open={reserveMenuOpen}
           onOpenChange={(o: boolean) => {
             setReserveMenuOpen(o);
-            if (!o) closeAll();
+            if (!o) closeModalsOnly();
           }}
           restaurant={selectedLegacy}
           onConfirm={goConfirm}
           onBack={backToReserve}
-          onClose={closeAll}
+          onClose={closeModalsOnly}
           draft={draft}
         />
       )}
@@ -309,7 +306,7 @@ export default function SearchPage() {
       {selectedLegacy && draft && (
         <ReservationConfirmMoodal
           open={confirmOpen}
-          onClose={closeAll}
+          onClose={closeModalsOnly}
           onBack={backToReserveMenu}
           onConfirm={goPayment}
           restaurant={selectedLegacy}
@@ -321,7 +318,7 @@ export default function SearchPage() {
       {selectedLegacy && draft && paymentOpen && (
         <PaymentModal
           open={paymentOpen}
-          onClose={closeAll}
+          onClose={closeModalsOnly}
           onOpenChange={setPaymentOpen}
           restaurant={selectedLegacy}
           draft={draft}
@@ -337,7 +334,7 @@ export default function SearchPage() {
           open={completeOpen}
           restaurant={selectedLegacy}
           draft={draft}
-          onClose={closeAll}
+          onClose={closeModalsOnly}
           autoCloseMs={5000}
         />
       )}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -57,12 +57,6 @@ export default function SearchPage() {
 
   const openDetail = async (restaurant: RestaurantSummary) => {
     const storeId = restaurant.id;
-    if (restaurant.location) {
-      setMapCenter({
-        lat: restaurant.location.lat,
-        lng: restaurant.location.lng,
-      });
-    }
 
     setSelectedStoreId(storeId);
     setDetailOpen(true);
@@ -183,6 +177,8 @@ export default function SearchPage() {
 
   const runSearch = async () => {
     setHasSearched(true);
+
+    setSelectedStoreId(null);
     const keyword = query.trim();
     setSearchError(null);
 
@@ -206,19 +202,8 @@ export default function SearchPage() {
       });
       setResults(items);
 
-      if (items.length === 1 && items[0].location) {
-        setMapCenter({
-          lat: items[0].location.lat,
-          lng: items[0].location.lng,
-        });
+      if (items.length === 1) {
         setSelectedStoreId(items[0].id);
-      } else if (items.length > 0) {
-        const first = items.find((x) => x.location);
-        if (first?.location) {
-          setMapCenter({ lat: first.location.lat, lng: first.location.lng });
-        }
-      } else {
-        setMapCenter({ lat: c.lat, lng: c.lng });
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : "검색에 실패했어요";

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -24,7 +24,7 @@ export type RestaurantSummary = {
   distanceKm?: number;
   thumbnailUrl?: string;
   isOpenNow?: boolean;
-  location?: Location;
+  location: Location;
 };
 
 export type BusinessHour = {

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -1,0 +1,66 @@
+export type Category = "KOREAN" | "CHINESE" | "JAPANESE" | "WESTERN" | "CAFE";
+
+export type Day =
+  | "MONDAY"
+  | "TUESDAY"
+  | "WEDNESDAY"
+  | "THURSDAY"
+  | "FRIDAY"
+  | "SATURDAY"
+  | "SUNDAY";
+
+export type Location = {
+  lat: number;
+  lng: number;
+};
+
+export type RestaurantSummary = {
+  id: string;
+  name: string;
+  address: string;
+  category: Category;
+  rating: number;
+  reviewCount: number;
+  distanceKm?: number;
+  thumbnailUrl?: string;
+  isOpenNow?: boolean;
+  location?: Location;
+};
+
+export type BusinessHour = {
+  day: Day;
+  openTime: string | null;
+  closeTime: string | null;
+  isClosed: boolean;
+};
+
+export type BreakTime = {
+  start: string;
+  end: string;
+};
+
+export type RestaurantDetail = {
+  id: string;
+  name: string;
+  description: string;
+  address: string;
+  phone: string;
+  category: Category;
+  rating: number;
+  reviewCount: number;
+  depositAmount: number;
+  mainImageUrl?: string;
+  tableImageUrls: string[];
+  businessHours: BusinessHour[];
+  breakTime?: BreakTime;
+  isOpenNow?: boolean;
+  location?: Location;
+};
+
+export const categoryLabel: Record<Category, string> = {
+  KOREAN: "한식",
+  CHINESE: "중식",
+  JAPANESE: "일식",
+  WESTERN: "양식",
+  CAFE: "카페",
+};


### PR DESCRIPTION
## 💡 개요
카카오맵 SDK를 동적 로딩으로 연동하고, 검색 결과를 지도 마커로 표시해서 선택상태와 검색 상태에 따라 자동으로 지도의 중심이 이동 및 줌 동작을 적용했습니다.

## 🔢 관련 이슈 링크
- Closes #44 

## 💻 작업내용
- Kakao Maps SDK 동적 로딩 유틸(src/lib/kakao.ts) 추가 및 .env(VITE_KAKAO_JS_KEY) 기반 키 주입
- KakaoMap 컴포넌트 구현: 지도생성, 마커 랜더링, 마커 클릭 이벤트(상세 모달 오픈) 연결
- 검색 결과에 따라 지도 bounds 자동 맞춤진행, 그중 식당 1개 선택시 자동으로 식당 중심으로 이동과 줌 진행
- SearchPage에서 검색/선택 상태 관리 정리 (식당 선택을 해제한 후에 다시 검색할시에 bounds 정상작동하도록 설정)

## 📌 변경사항PR
- [x] FEAT: 새로운 기능 추가
- [ ] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [x] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
- 마커 스타일 작업은 추후에 진행예정입니다!
- 기본 주소는 서울시청으로 잡아두었으니 그점 참고 부탁드립니다!

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카카오 지도 통합: 인터랙티브 맵, 마커 선택·하이라이트·정보창, SDK 런타임 로더
  * 검색·상세 흐름용 모의 API와 상세 샘플 데이터 제공

* **Improvements**
  * 검색 결과와 상세 정보 형식 통일(거리, 썸네일, 위치 포함)
  * 상세 모달의 상태관리(로딩·성공·오류) 및 재시도 UX 추가
  * 카테고리 레이블, 운영시간·휴게시간 표시 개선, 테이블 사진 노출 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->