### PR TITLE
feat: 로그인 / 회원가입 API 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 VITE_API_URL=https://api.example.com
 
 VITE_KAKAO_JS_KEY=
+
+VITE_GOOGLE_CLIENT_ID=
+

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       content="자리 자체를 예약하는 새로운 식문화 플랫폼 웹 애플리케이션 서비스"
     />
     <meta property="og:image" content="/eatsfineLogo.svg" />
+    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
       content="자리 자체를 예약하는 새로운 식문화 플랫폼 웹 애플리케이션 서비스"
     />
     <meta property="og:image" content="/eatsfineLogo.svg" />
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@react-oauth/google": "^0.13.4",
     "@tanstack/react-query": "^5.90.16",
     "axios": "^1.13.2",
     "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "immer": "^11.1.3",
     "lucide-react": "^0.562.0",
     "react": "^19.2.0",
     "react-day-picker": "^9.13.0",
@@ -31,7 +32,8 @@
     "react-hook-form": "^7.69.0",
     "react-router-dom": "^7.11.0",
     "tailwind-merge": "^3.4.0",
-    "zod": "^4.3.4"
+    "zod": "^4.3.4",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      immer:
+        specifier: ^11.1.3
+        version: 11.1.3
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
@@ -71,6 +74,9 @@ importers:
       zod:
         specifier: ^4.3.4
         version: 4.3.4
+      zustand:
+        specifier: ^5.0.11
+        version: 5.0.11(@types/react@19.2.7)(immer@11.1.3)(react@19.2.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -1454,6 +1460,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@11.1.3:
+    resolution: {integrity: sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1944,6 +1953,24 @@ packages:
 
   zod@4.3.4:
     resolution: {integrity: sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==}
+
+  zustand@5.0.11:
+    resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -3172,6 +3199,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@11.1.3: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -3561,3 +3590,9 @@ snapshots:
       zod: 4.3.4
 
   zod@4.3.4: {}
+
+  zustand@5.0.11(@types/react@19.2.7)(immer@11.1.3)(react@19.2.3):
+    optionalDependencies:
+      '@types/react': 19.2.7
+      immer: 11.1.3
+      react: 19.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
+      '@react-oauth/google':
+        specifier: ^0.13.4
+        version: 0.13.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-query':
         specifier: ^5.90.16
         version: 5.90.16(react@19.2.3)
@@ -765,6 +768,12 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@react-oauth/google@0.13.4':
+    resolution: {integrity: sha512-hGKyNEH+/PK8M0sFEuo3MAEk0txtHpgs94tDQit+s2LXg7b6z53NtzHfqDvoB2X8O6lGB+FRg80hY//X6hfD+w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
@@ -2494,6 +2503,11 @@ snapshots:
       '@types/react': 19.2.7
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@react-oauth/google@0.13.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,9 +74,20 @@ const router = createBrowserRouter(routes);
 export default function App() {
   // 카카오 sdk 초기화
   useEffect(() => {
-    if (window.Kakao && !window.Kakao.isInitialized()) {
-      window.Kakao.init(import.meta.env.VITE_KAKAO_JS_KEY);
-    }
+    const tryInit = () => {
+      if (window.Kakao && !window.Kakao.isInitialized()) {
+        window.Kakao.init(import.meta.env.VITE_KAKAO_JS_KEY);
+        return true;
+      }
+      return false;
+    };
+
+    if (tryInit()) return;
+
+    const interval = setInterval(() => {
+      if (tryInit()) clearInterval(interval);
+    }, 200);
+    return () => clearInterval(interval);
   }, []);
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,12 @@ import SubscriptionPage from "./pages/myPage/subscriptionPage";
 import ReservationPage from "./pages/myPage/reservationPage";
 import StorePage from "./pages/myPage/storePage";
 import OwnerPage from "./pages/ownerPage";
-import { useEffect } from "react";
+import OAuthCallbackPage from "./pages/OAuthCallbackPage";
+import LoginErrorPage from "./pages/LoginErrorPage";
 
 const routes: RouteObject[] = [
+  { path: "/oauth/callback", element: <OAuthCallbackPage /> },
+  { path: "/login/error", element: <LoginErrorPage /> },
   {
     element: <PublicLayout />,
     errorElement: <NotFound />,
@@ -72,24 +75,6 @@ const routes: RouteObject[] = [
 const router = createBrowserRouter(routes);
 
 export default function App() {
-  // 카카오 sdk 초기화
-  useEffect(() => {
-    const tryInit = () => {
-      if (window.Kakao && !window.Kakao.isInitialized()) {
-        window.Kakao.init(import.meta.env.VITE_KAKAO_JS_KEY);
-        return true;
-      }
-      return false;
-    };
-
-    if (tryInit()) return;
-
-    const interval = setInterval(() => {
-      if (tryInit()) clearInterval(interval);
-    }, 200);
-    return () => clearInterval(interval);
-  }, []);
-
   return (
     <>
       <RouterProvider router={router} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import SubscriptionPage from "./pages/myPage/subscriptionPage";
 import ReservationPage from "./pages/myPage/reservationPage";
 import StorePage from "./pages/myPage/storePage";
 import OwnerPage from "./pages/ownerPage";
+import { useEffect } from "react";
 
 const routes: RouteObject[] = [
   {
@@ -72,6 +73,13 @@ const routes: RouteObject[] = [
 const router = createBrowserRouter(routes);
 
 export default function App() {
+  // 카카오 sdk 초기화
+  useEffect(() => {
+    if (window.Kakao && !window.Kakao.isInitialized()) {
+      window.Kakao.init(import.meta.env.VITE_KAKAO_JS_KEY);
+    }
+  }, []);
+
   return (
     <>
       <RouterProvider router={router} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,8 +23,7 @@ import { useEffect } from "react";
 
 const routes: RouteObject[] = [
   {
-    //TODO: 로그아웃처리 필요
-    element: <PublicLayout onLogOut={() => {}} />,
+    element: <PublicLayout />,
     errorElement: <NotFound />,
     children: [
       { path: "/search", element: <SearchPage /> },

--- a/src/api/api.error.ts
+++ b/src/api/api.error.ts
@@ -5,7 +5,7 @@ export function isApiResponse(data: unknown): data is ApiResponse<unknown> {
   return (
     typeof data === "object" &&
     data !== null &&
-    "success" in data &&
+    "isSuccess" in data &&
     "code" in data &&
     "message" in data
   );

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,6 +2,7 @@ import type { ApiResponse } from "@/types/api";
 import type {
   RequestLoginDto,
   RequestSignupDto,
+  RequestSocialLoginDto,
   ResponseLoginDto,
   ResponseLogoutDto,
   ResponseRefreshDto,
@@ -24,6 +25,17 @@ export const postLogin = async (
 ): Promise<ApiResponse<ResponseLoginDto>> => {
   const { data } = await api.post<ApiResponse<ResponseLoginDto>>(
     "/auth/login",
+    body,
+  );
+  return data;
+};
+
+export const postSocialLogin = async (
+  provider: "kakao" | "google",
+  body: RequestSocialLoginDto,
+): Promise<ApiResponse<ResponseLoginDto>> => {
+  const { data } = await api.post<ApiResponse<ResponseLoginDto>>(
+    `/auth/social/${provider}`,
     body,
   );
   return data;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -53,6 +53,8 @@ export const logout = async () => {
 };
 
 export const postRefresh = async (): Promise<ResponseRefreshDto> => {
+  // refresh는 api 인스턴스를 사용하지 않음
+  // 이유: response interceptor(401 → refresh)가 다시 실행되는 것을 방지하기 위함
   const { data } = await axios.post<ApiResponse<ResponseRefreshDto>>(
     `${import.meta.env.VITE_API_URL}/api/auth/reissue`,
     {},

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,11 +1,11 @@
 import type { ApiResponse } from "@/types/api";
 import type {
-  RequestLoginDto,
   RequestSignupDto,
+  ResponseSignupDto,
+  RequestLoginDto,
   ResponseLoginDto,
   ResponseLogoutDto,
   ResponseRefreshDto,
-  ResponseSignupDto,
 } from "@/types/auth";
 import { api } from "./axios";
 import { useAuthStore } from "@/stores/useAuthStore";
@@ -13,28 +13,28 @@ import axios from "axios";
 
 export const postSignup = async (
   body: RequestSignupDto,
-): Promise<ApiResponse<ResponseSignupDto>> => {
+): Promise<ResponseSignupDto> => {
   const { data } = await api.post<ApiResponse<ResponseSignupDto>>(
-    "/auth/signup",
+    "/api/auth/signup",
     body,
   );
-  return data;
+  return data.result;
 };
 
 export const postLogin = async (
   body: RequestLoginDto,
-): Promise<ApiResponse<ResponseLoginDto>> => {
+): Promise<ResponseLoginDto> => {
   const { data } = await api.post<ApiResponse<ResponseLoginDto>>(
-    "/auth/login",
+    "/api/auth/login",
     body,
   );
-  return data;
+  return data.result;
 };
 
-export const postLogout = async () => {
+export const postLogout = async (): Promise<ResponseLogoutDto> => {
   const { data } =
-    await api.post<ApiResponse<ResponseLogoutDto>>("/auth/logout");
-  return data;
+    await api.delete<ApiResponse<ResponseLogoutDto>>("/api/auth/logout");
+  return data.result;
 };
 
 export const clearAuth = () => {
@@ -52,14 +52,14 @@ export const logout = async () => {
   }
 };
 
-export const postRefresh = async () => {
+export const postRefresh = async (): Promise<ResponseRefreshDto> => {
   const { data } = await axios.post<ApiResponse<ResponseRefreshDto>>(
-    `${import.meta.env.VITE_API_URL}/auth/refresh`,
+    `${import.meta.env.VITE_API_URL}/api/auth/reissue`,
     {},
     {
       withCredentials: true,
       timeout: 10000,
     },
   );
-  return data;
+  return data.result;
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -63,5 +63,8 @@ export const postRefresh = async (): Promise<ResponseRefreshDto> => {
       timeout: 10000,
     },
   );
+  if (!data.isSuccess) {
+    throw new Error(data.message || "토큰 재발급 실패");
+  }
   return data.result;
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -14,11 +14,8 @@ import axios from "axios";
 export const postSignup = async (
   body: RequestSignupDto,
 ): Promise<ResponseSignupDto> => {
-  const { data } = await api.post<ApiResponse<ResponseSignupDto>>(
-    "/api/auth/signup",
-    body,
-  );
-  return data.result;
+  const { data } = await api.post<ResponseSignupDto>("/api/auth/signup", body);
+  return data;
 };
 
 export const postLogin = async (

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -66,10 +66,11 @@ export const logout = async () => {
 
 export const postRefresh = async () => {
   const { data } = await axios.post<ApiResponse<ResponseRefreshDto>>(
-    `${import.meta.env.VITE_API_BASE_URL}/auth/refresh`,
+    `${import.meta.env.VITE_API_URL}/auth/refresh`,
     {},
     {
       withCredentials: true,
+      timeout: 10000,
     },
   );
   return data;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,57 @@
+import type { ApiResponse } from "@/types/api";
+import type {
+  RequestLoginDto,
+  RequestSignupDto,
+  ResponseLoginDto,
+  ResponseLogoutDto,
+  ResponseRefreshDto,
+  ResponseSignupDto,
+} from "@/types/auth";
+import { api } from "./axios";
+
+export const postSignup = async (
+  body: RequestSignupDto,
+): Promise<ApiResponse<ResponseSignupDto>> => {
+  const { data } = await api.post<ApiResponse<ResponseSignupDto>>(
+    "/auth/signup",
+    body,
+  );
+  return data;
+};
+
+export const postLogin = async (
+  body: RequestLoginDto,
+): Promise<ApiResponse<ResponseLoginDto>> => {
+  const { data } = await api.post<ApiResponse<ResponseLoginDto>>(
+    "/auth/login",
+    body,
+  );
+  return data;
+};
+
+export const postLogout = async () => {
+  const { data } =
+    await api.post<ApiResponse<ResponseLogoutDto>>("/auth/logout");
+  return data;
+};
+
+export const clearAuth = () => {
+  localStorage.removeItem("accessToken");
+  window.location.href = "/";
+};
+
+export const logout = async () => {
+  try {
+    await postLogout();
+  } catch (e) {
+    console.error(e);
+  } finally {
+    clearAuth();
+  }
+};
+
+export const postRefresh = async () => {
+  const { data } =
+    await api.post<ApiResponse<ResponseRefreshDto>>("/auth/refresh");
+  return data;
+};

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,7 +2,6 @@ import type { ApiResponse } from "@/types/api";
 import type {
   RequestLoginDto,
   RequestSignupDto,
-  RequestSocialLoginDto,
   ResponseLoginDto,
   ResponseLogoutDto,
   ResponseRefreshDto,
@@ -27,17 +26,6 @@ export const postLogin = async (
 ): Promise<ApiResponse<ResponseLoginDto>> => {
   const { data } = await api.post<ApiResponse<ResponseLoginDto>>(
     "/auth/login",
-    body,
-  );
-  return data;
-};
-
-export const postSocialLogin = async (
-  provider: "kakao" | "google",
-  body: RequestSocialLoginDto,
-): Promise<ApiResponse<ResponseLoginDto>> => {
-  const { data } = await api.post<ApiResponse<ResponseLoginDto>>(
-    `/auth/social/${provider}`,
     body,
   );
   return data;

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -9,6 +9,8 @@ import type {
   ResponseSignupDto,
 } from "@/types/auth";
 import { api } from "./axios";
+import { useAuthStore } from "@/stores/useAuthStore";
+import axios from "axios";
 
 export const postSignup = async (
   body: RequestSignupDto,
@@ -48,22 +50,27 @@ export const postLogout = async () => {
 };
 
 export const clearAuth = () => {
-  localStorage.removeItem("accessToken");
-  window.location.href = "/";
+  useAuthStore.getState().actions.logout();
 };
 
+// 로그아웃은 사용자 의도이므로 서버 실패와 무관하게 클라이언트 인증 정보를 제거
 export const logout = async () => {
   try {
     await postLogout();
   } catch (e) {
-    console.error(e);
+    console.warn("서버 로그아웃 실패(하지만 클라이언트 로그아웃은 진행함):", e);
   } finally {
     clearAuth();
   }
 };
 
 export const postRefresh = async () => {
-  const { data } =
-    await api.post<ApiResponse<ResponseRefreshDto>>("/auth/refresh");
+  const { data } = await axios.post<ApiResponse<ResponseRefreshDto>>(
+    `${import.meta.env.VITE_API_BASE_URL}/auth/refresh`,
+    {},
+    {
+      withCredentials: true,
+    },
+  );
   return data;
 };

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -99,7 +99,7 @@ api.interceptors.response.use(
         // 재발급 실패 시 로그아웃 처리
         console.error("토큰 재발급 실패:", refreshError);
         clearAuth();
-        return Promise.reject(refreshError);
+        return Promise.reject(normalizeApiError(refreshError as AxiosError));
       }
     }
 

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -13,6 +13,8 @@ import { Input } from "@/components/ui/input";
 import { useForm } from "react-hook-form";
 import { type LoginFormValues, loginSchema } from "./login.schema";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { postLogin } from "@/api/auth";
+import type { ApiError } from "@/types/api";
 
 interface LoginDialogProps {
   isOpen: boolean;
@@ -56,14 +58,18 @@ export function LoginDialog({
 
   const handleEmailLogin = async (data: LoginFormValues) => {
     try {
-      console.log("Email login:", data);
-      //await API
+      const response = await postLogin(data);
 
-      alert("로그인 완료되었습니다.");
-
-      onClose();
-    } catch (e) {
-      console.error("Login error:", e);
+      if (response.success) {
+        localStorage.setItem("accessToken", response.data.accessToken);
+        onClose();
+        window.location.reload();
+      }
+    } catch (error: unknown) {
+      console.error("Login error:", error);
+      const apiError = error as ApiError;
+      const errorMessage = apiError.message || "로그인 중 문제가 발생했습니다.";
+      alert(errorMessage);
     }
   };
 

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -14,6 +14,7 @@ import { useForm } from "react-hook-form";
 import { type LoginFormValues, loginSchema } from "./login.schema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEmailLogin } from "@/hooks/queries/useAuth";
+import { getErrorMessage } from "@/utils/error";
 
 interface LoginDialogProps {
   isOpen: boolean;
@@ -62,9 +63,9 @@ export function LoginDialog({
   const handleEmailLogin = (data: LoginFormValues) => {
     emailLoginMutation.mutate(data, {
       onSuccess: () => onClose(),
-      onError: (error) =>
-        // TODO: 에러 유틸 함수 추가 예정
-        alert(error.message || "로그인 중 문제가 발생했습니다."),
+      onError: (error) => {
+        alert(getErrorMessage(error));
+      },
     });
   };
 

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -54,6 +54,9 @@ export function LoginDialog({
 
   const handleSocialLogin = (provider: "google" | "kakao") => {
     const backendUrl = import.meta.env.VITE_API_URL;
+    if (!backendUrl) {
+      return alert("서버 URL이 설정되어 있지 않습니다. 관리자에게 문의하세요.");
+    }
     window.location.href = `${backendUrl}/oauth2/authorization/${provider}`;
   };
 

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -207,22 +207,6 @@ export function LoginDialog({
                   )}
                 </div>
 
-                <div className="flex items-center justify-between text-sm">
-                  <a
-                    href="#find-id"
-                    className="text-gray-600 hover:text-blue-600 transition-colors"
-                  >
-                    아이디 찾기
-                  </a>
-                  <span className="text-gray-300">|</span>
-                  <a
-                    href="#find-password"
-                    className="text-gray-600 hover:text-blue-600 transition-colors"
-                  >
-                    비밀번호 찾기
-                  </a>
-                </div>
-
                 <Button
                   type="submit"
                   disabled={emailLoginMutation.isPending}
@@ -234,7 +218,7 @@ export function LoginDialog({
                 <Button
                   type="button"
                   variant="ghost"
-                  className="w-full cursor-pointer"
+                  className="w-full h-12 cursor-pointer"
                   onClick={() => setShowEmailLogin(false)}
                 >
                   다른 방법으로 로그인

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -84,8 +84,12 @@ export function LoginDialog({
     if (!window.Kakao) {
       return alert("카카오 스크립트가 아직 로드되지 않았습니다.");
     }
+    const kakaoKey = import.meta.env.VITE_KAKAO_JS_KEY;
+    if (!kakaoKey) {
+      return alert("VITE_KAKAO_JS_KEY가 설정되어 있지 않습니다.");
+    }
     if (!window.Kakao.isInitialized()) {
-      window.Kakao.init(import.meta.env.VITE_KAKAO_JS_KEY);
+      window.Kakao.init(kakaoKey);
     }
     window.Kakao.Auth.login({
       success: (authObj: KakaoAuthSuccessResponse) => {

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -14,7 +14,6 @@ import { useForm } from "react-hook-form";
 import { type LoginFormValues, loginSchema } from "./login.schema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEmailLogin } from "@/hooks/queries/useAuth";
-import type { ApiError } from "@/types/api";
 
 interface LoginDialogProps {
   isOpen: boolean;
@@ -64,7 +63,8 @@ export function LoginDialog({
     emailLoginMutation.mutate(data, {
       onSuccess: () => onClose(),
       onError: (error) =>
-        alert((error as ApiError).message || "로그인 중 문제가 발생했습니다."),
+        // TODO: 에러 유틸 함수 추가 예정
+        alert(error.message || "로그인 중 문제가 발생했습니다."),
     });
   };
 

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -54,8 +54,7 @@ export function LoginDialog({
 
   const handleSocialLogin = (provider: "google" | "kakao") => {
     const backendUrl = import.meta.env.VITE_API_URL;
-    // TODO: url 수정 예정
-    window.location.href = `${backendUrl}/auth/social/${provider}`;
+    window.location.href = `${backendUrl}/oauth2/authorization/${provider}`;
   };
 
   const handleEmailLogin = (data: LoginFormValues) => {

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -50,9 +50,9 @@ export function LoginDialog({
     }
   }, [isOpen, reset]);
 
-  const handleSocialLogin = (provider: string) => {
-    console.log(`Login with ${provider}`);
-    alert("로그인 완료되었습니다.");
+  const handleSocialLogin = async (provider: "google" | "kakao") => {
+    // TODO: postSocialLogin(provider, { accessToken })
+    alert(`${provider} 로그인은 백엔드 배포 후 연동 예정입니다`);
     onClose();
   };
 

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -15,7 +15,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { signupSchema, type SignupFormValues } from "./signup.schema";
 import { useEffect } from "react";
 import { phoneNumber } from "@/utils/phoneNumber";
-import type { ApiError } from "@/types/api";
 import { useEmailSignup } from "@/hooks/queries/useAuth";
 
 interface SignupDialogProps {
@@ -76,9 +75,8 @@ export function SignupDialog({
         onSwitchToLogin();
       },
       onError: (error) =>
-        alert(
-          (error as ApiError).message || "회원가입 중 문제가 발생했습니다.",
-        ),
+        // TODO: 에러 유틸 함수 추가 예정
+        alert(error.message || "회원가입 중 문제가 발생했습니다."),
     });
   };
 

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -133,38 +133,7 @@ export function SignupDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-4 mt-2">
-          <Controller
-            control={control}
-            name="role"
-            render={({ field }) => (
-              <div className="flex justify-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => field.onChange("customer")}
-                  className={
-                    field.value === "customer"
-                      ? "bg-blue-600 text-white h-12 w-full rounded-lg transition-colors"
-                      : "bg-gray-200 text-gray-600 h-12 w-full rounded-lg hover:bg-gray-300 transition-colors cursor-pointer"
-                  }
-                >
-                  고객
-                </button>
-                <button
-                  type="button"
-                  onClick={() => field.onChange("owner")}
-                  className={
-                    field.value === "owner"
-                      ? "bg-blue-600 text-white h-12 w-full rounded-lg transition-colors"
-                      : "bg-gray-200 text-gray-600 h-12 w-full rounded-lg hover:bg-gray-300 transition-colors cursor-pointer"
-                  }
-                >
-                  점주
-                </button>
-              </div>
-            )}
-          />
-
+        <div className="space-y-4 py-4">
           {/* 소셜 회원가입 */}
           <div className="flex flex-col gap-4 py-4">
             <Button

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -125,12 +125,6 @@ export function SignupDialog({
               />
               카카오톡으로 가입하기
             </Button>
-
-            <p className="text-xs text-center text-gray-500 px-2 break-keep">
-              소셜 계정으로 가입 시 <span className="underline">이용약관</span>,{" "}
-              <span className="underline">개인정보처리방침</span> 에 동의하는
-              것으로 간주합니다.
-            </p>
           </div>
 
           <div className="relative">

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -16,18 +16,13 @@ import { signupSchema, type SignupFormValues } from "./signup.schema";
 import { useEffect } from "react";
 import { phoneNumber } from "@/utils/phoneNumber";
 import type { ApiError } from "@/types/api";
-import { useGoogleLogin } from "@react-oauth/google";
-import { useEmailSignup, useSocialLogin } from "@/hooks/queries/useAuth";
+import { useEmailSignup } from "@/hooks/queries/useAuth";
 
 interface SignupDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onSwitchToLogin: () => void;
 }
-
-type KakaoAuthSuccessResponse = {
-  access_token: string;
-};
 
 const defaultValues: SignupFormValues = {
   role: "customer",
@@ -47,7 +42,6 @@ export function SignupDialog({
   onSwitchToLogin,
 }: SignupDialogProps) {
   const signupMutation = useEmailSignup();
-  const socialLoginMutation = useSocialLogin();
 
   const {
     register,
@@ -68,47 +62,10 @@ export function SignupDialog({
     }
   }, [isOpen, reset]);
 
-  const handleSocialLogin = (provider: "google" | "kakao", token: string) => {
-    socialLoginMutation.mutate(
-      { provider, token },
-      {
-        onSuccess: () => onClose(),
-        onError: (error) =>
-          alert(
-            (error as ApiError).message || "회원가입 중 문제가 발생했습니다.",
-          ),
-      },
-    );
-  };
-
-  const handleGoogleLogin = useGoogleLogin({
-    onSuccess: (response) => {
-      handleSocialLogin("google", response.access_token);
-    },
-    onError: (errorResponse) => {
-      console.error("구글 로그인 실패:", errorResponse);
-    },
-  });
-
-  const handleKakaoLogin = () => {
-    if (!window.Kakao) {
-      return alert("카카오 스크립트가 아직 로드되지 않았습니다.");
-    }
-    const kakaoKey = import.meta.env.VITE_KAKAO_JS_KEY;
-    if (!kakaoKey) {
-      return alert("VITE_KAKAO_JS_KEY가 설정되어 있지 않습니다.");
-    }
-    if (!window.Kakao.isInitialized()) {
-      window.Kakao.init(kakaoKey);
-    }
-    window.Kakao.Auth.login({
-      success: (authObj: KakaoAuthSuccessResponse) => {
-        handleSocialLogin("kakao", authObj.access_token);
-      },
-      fail: (error: unknown) => {
-        console.error("카카오 로그인 실패:", error);
-      },
-    });
+  const handleSocialLogin = (provider: "google" | "kakao") => {
+    const backendUrl = import.meta.env.VITE_API_URL;
+    // TODO: url 수정 예정
+    window.location.href = `${backendUrl}/auth/social/${provider}`;
   };
 
   const onSubmit = (formData: SignupFormValues) => {
@@ -144,7 +101,7 @@ export function SignupDialog({
               type="button"
               variant="outline"
               className="w-full h-12 text-base cursor-pointer"
-              onClick={() => handleGoogleLogin()}
+              onClick={() => handleSocialLogin("google")}
             >
               <img
                 src="/icons/google.svg"
@@ -158,7 +115,7 @@ export function SignupDialog({
               type="button"
               variant="outline"
               className="w-full h-12 text-base bg-[#FEE500] hover:bg-[#E6CF00] border-0 cursor-pointer text-black"
-              onClick={handleKakaoLogin}
+              onClick={() => handleSocialLogin("kakao")}
             >
               <img
                 src="/icons/kakao.svg"

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -64,6 +64,9 @@ export function SignupDialog({
 
   const handleSocialLogin = (provider: "google" | "kakao") => {
     const backendUrl = import.meta.env.VITE_API_URL;
+    if (!backendUrl) {
+      return alert("서버 URL이 설정되어 있지 않습니다. 관리자에게 문의하세요.");
+    }
     window.location.href = `${backendUrl}/oauth2/authorization/${provider}`;
   };
 

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -15,14 +15,19 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { signupSchema, type SignupFormValues } from "./signup.schema";
 import { useEffect } from "react";
 import { phoneNumber } from "@/utils/phoneNumber";
-import { postSignup } from "@/api/auth";
+import { postSignup, postSocialLogin } from "@/api/auth";
 import type { ApiError } from "@/types/api";
+import { useGoogleLogin } from "@react-oauth/google";
 
 interface SignupDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onSwitchToLogin: () => void;
 }
+
+type KakaoAuthSuccessResponse = {
+  access_token: string;
+};
 
 const defaultValues: SignupFormValues = {
   role: "customer",
@@ -60,10 +65,51 @@ export function SignupDialog({
     }
   }, [isOpen, reset]);
 
-  const handleSocialLogin = async (provider: "google" | "kakao") => {
-    // TODO: postSocialLogin(provider, { accessToken })
-    alert(`${provider} 로그인은 백엔드 배포 후 연동 예정입니다`);
-    onClose();
+  const handleSocialLogin = async (
+    provider: "google" | "kakao",
+    token: string,
+  ) => {
+    try {
+      const response = await postSocialLogin(provider, { accessToken: token });
+
+      if (response.success) {
+        localStorage.setItem("accessToken", response.data.accessToken);
+        onClose();
+        window.location.reload();
+      }
+    } catch (error) {
+      console.error("SocialLogin error:", error);
+      const apiError = error as ApiError;
+      const errorMessage =
+        apiError.message || `${provider} 로그인 중 문제가 발생했습니다.`;
+      alert(errorMessage);
+    }
+  };
+
+  const handleGoogleLogin = useGoogleLogin({
+    onSuccess: (response) => {
+      handleSocialLogin("google", response.access_token);
+    },
+    onError: (errorResponse) => {
+      console.error("구글 로그인 실패:", errorResponse);
+    },
+  });
+
+  const handleKakaoLogin = () => {
+    if (!window.Kakao) {
+      return alert("카카오 스크립트가 아직 로드되지 않았습니다.");
+    }
+    if (!window.Kakao.isInitialized()) {
+      window.Kakao.init(import.meta.env.VITE_KAKAO_JS_KEY);
+    }
+    window.Kakao.Auth.login({
+      success: (authObj: KakaoAuthSuccessResponse) => {
+        handleSocialLogin("kakao", authObj.access_token);
+      },
+      fail: (error: unknown) => {
+        console.error("카카오 로그인 실패:", error);
+      },
+    });
   };
 
   const onSubmit = async (formData: SignupFormValues) => {
@@ -142,7 +188,7 @@ export function SignupDialog({
               type="button"
               variant="outline"
               className="w-full h-12 text-base cursor-pointer"
-              onClick={() => handleSocialLogin("google")}
+              onClick={() => handleGoogleLogin()}
             >
               <img
                 src="/icons/google.svg"
@@ -156,7 +202,7 @@ export function SignupDialog({
               type="button"
               variant="outline"
               className="w-full h-12 text-base bg-[#FEE500] hover:bg-[#E6CF00] border-0 cursor-pointer text-black"
-              onClick={() => handleSocialLogin("kakao")}
+              onClick={handleKakaoLogin}
             >
               <img
                 src="/icons/kakao.svg"

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -16,6 +16,7 @@ import { signupSchema, type SignupFormValues } from "./signup.schema";
 import { useEffect } from "react";
 import { phoneNumber } from "@/utils/phoneNumber";
 import { useEmailSignup } from "@/hooks/queries/useAuth";
+import { getErrorMessage } from "@/utils/error";
 
 interface SignupDialogProps {
   isOpen: boolean;
@@ -74,9 +75,9 @@ export function SignupDialog({
         alert("가입 완료되었습니다.");
         onSwitchToLogin();
       },
-      onError: (error) =>
-        // TODO: 에러 유틸 함수 추가 예정
-        alert(error.message || "회원가입 중 문제가 발생했습니다."),
+      onError: (error) => {
+        alert(getErrorMessage(error));
+      },
     });
   };
 

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -15,6 +15,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { signupSchema, type SignupFormValues } from "./signup.schema";
 import { useEffect } from "react";
 import { phoneNumber } from "@/utils/phoneNumber";
+import { postSignup } from "@/api/auth";
+import type { ApiError } from "@/types/api";
 
 interface SignupDialogProps {
   isOpen: boolean;
@@ -64,16 +66,28 @@ export function SignupDialog({
     onClose();
   };
 
-  const onSubmit = async (data: SignupFormValues) => {
+  const onSubmit = async (formData: SignupFormValues) => {
     try {
-      console.log("Signup data:", data);
-      //await API
+      const requestBody = {
+        role: formData.role!,
+        name: formData.name,
+        email: formData.email,
+        phone: formData.phone,
+        password: formData.password,
+      };
 
-      alert("가입 완료되었습니다.");
+      const response = await postSignup(requestBody);
 
-      onClose();
-    } catch (e) {
-      console.error("Signup error:", e);
+      if (response.success) {
+        alert("가입 완료되었습니다.");
+        onSwitchToLogin();
+      }
+    } catch (error: unknown) {
+      console.error("Signup error:", error);
+      const apiError = error as ApiError;
+      const errorMessage =
+        apiError.message || "회원가입 중 문제가 발생했습니다.";
+      alert(errorMessage);
     }
   };
 
@@ -201,7 +215,6 @@ export function SignupDialog({
                     type="tel"
                     placeholder="010-1234-5678"
                     className="h-12"
-                    {...register("phone")}
                     onChange={(e) => {
                       const formatted = phoneNumber(e.target.value);
                       field.onChange(formatted);

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -14,6 +14,7 @@ import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { signupSchema, type SignupFormValues } from "./signup.schema";
 import { useEffect } from "react";
+import { phoneNumber } from "@/utils/phoneNumber";
 
 interface SignupDialogProps {
   isOpen: boolean;
@@ -21,7 +22,8 @@ interface SignupDialogProps {
   onSwitchToLogin: () => void;
 }
 
-const defaultValues = {
+const defaultValues: SignupFormValues = {
+  role: "customer",
   name: "",
   email: "",
   phone: "",
@@ -88,7 +90,38 @@ export function SignupDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-4">
+        <div className="space-y-4 py-4 mt-2">
+          <Controller
+            control={control}
+            name="role"
+            render={({ field }) => (
+              <div className="flex justify-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => field.onChange("customer")}
+                  className={
+                    field.value === "customer"
+                      ? "bg-blue-600 text-white h-12 w-full rounded-lg transition-colors"
+                      : "bg-gray-200 text-gray-600  h-12 w-full rounded-lg hover:bg-gray-300 transition-colors cursor-pointer"
+                  }
+                >
+                  고객
+                </button>
+                <button
+                  type="button"
+                  onClick={() => field.onChange("owner")}
+                  className={
+                    field.value === "owner"
+                      ? "bg-blue-600 text-white h-12 w-full rounded-lg transition-colors"
+                      : "bg-gray-200 text-gray-600 h-12 w-full rounded-lg hover:bg-gray-300 transition-colors cursor-pointer"
+                  }
+                >
+                  점주
+                </button>
+              </div>
+            )}
+          />
+
           {/* 소셜 회원가입 */}
           <div className="flex flex-col gap-4 py-4">
             <Button
@@ -158,12 +191,23 @@ export function SignupDialog({
 
             <div className="space-y-2">
               <Label htmlFor="signup-phone">휴대폰 번호</Label>
-              <Input
-                id="signup-phone"
-                type="tel"
-                placeholder="01012345678"
-                className="h-12"
-                {...register("phone")}
+              <Controller
+                name="phone"
+                control={control}
+                render={({ field }) => (
+                  <Input
+                    {...field}
+                    id="signup-phone"
+                    type="tel"
+                    placeholder="010-1234-5678"
+                    className="h-12"
+                    {...register("phone")}
+                    onChange={(e) => {
+                      const formatted = phoneNumber(e.target.value);
+                      field.onChange(formatted);
+                    }}
+                  />
+                )}
               />
               {errors.phone && (
                 <p className="text-sm text-red-500">{errors.phone.message}</p>

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -25,15 +25,14 @@ interface SignupDialogProps {
 }
 
 const defaultValues: SignupFormValues = {
-  role: "customer",
   name: "",
   email: "",
-  phone: "",
+  phoneNumber: "",
   password: "",
-  confirmPassword: "",
-  terms: false,
-  privacy: false,
-  marketing: false,
+  passwordConfirm: "",
+  tosConsent: false,
+  privacyConsent: false,
+  marketingConsent: false,
 };
 
 export function SignupDialog({
@@ -173,7 +172,7 @@ export function SignupDialog({
             <div className="space-y-2">
               <Label htmlFor="signup-phone">휴대폰 번호</Label>
               <Controller
-                name="phone"
+                name="phoneNumber"
                 control={control}
                 render={({ field }) => (
                   <Input
@@ -189,8 +188,10 @@ export function SignupDialog({
                   />
                 )}
               />
-              {errors.phone && (
-                <p className="text-sm text-red-500">{errors.phone.message}</p>
+              {errors.phoneNumber && (
+                <p className="text-sm text-red-500">
+                  {errors.phoneNumber.message}
+                </p>
               )}
             </div>
 
@@ -217,11 +218,11 @@ export function SignupDialog({
                 type="password"
                 placeholder="비밀번호를 다시 입력하세요"
                 className="h-12"
-                {...register("confirmPassword")}
+                {...register("passwordConfirm")}
               />
-              {errors.confirmPassword && (
+              {errors.passwordConfirm && (
                 <p className="text-sm text-red-500">
-                  {errors.confirmPassword.message}
+                  {errors.passwordConfirm.message}
                 </p>
               )}
             </div>
@@ -231,7 +232,7 @@ export function SignupDialog({
               <div className="flex items-center space-x-2">
                 <Controller
                   control={control}
-                  name="terms"
+                  name="tosConsent"
                   render={({ field }) => (
                     <Checkbox
                       checked={field.value}
@@ -245,16 +246,16 @@ export function SignupDialog({
                   <span className="text-red-500">*</span> 이용약관에 동의합니다
                 </Label>
               </div>
-              {errors.terms && (
+              {errors.tosConsent && (
                 <p className="text-sm text-red-500 pl-9">
-                  {errors.terms.message}
+                  {errors.tosConsent.message}
                 </p>
               )}
 
               <div className="flex items-center space-x-2">
                 <Controller
                   control={control}
-                  name="privacy"
+                  name="privacyConsent"
                   render={({ field }) => (
                     <Checkbox
                       checked={field.value}
@@ -269,16 +270,16 @@ export function SignupDialog({
                   동의합니다
                 </Label>
               </div>
-              {errors.privacy && (
+              {errors.privacyConsent && (
                 <p className="text-sm text-red-500 pl-9">
-                  {errors.privacy.message}
+                  {errors.privacyConsent.message}
                 </p>
               )}
 
               <div className="flex items-center space-x-2">
                 <Controller
                   control={control}
-                  name="marketing"
+                  name="marketingConsent"
                   render={({ field }) => (
                     <Checkbox
                       checked={field.value}

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -94,8 +94,12 @@ export function SignupDialog({
     if (!window.Kakao) {
       return alert("카카오 스크립트가 아직 로드되지 않았습니다.");
     }
+    const kakaoKey = import.meta.env.VITE_KAKAO_JS_KEY;
+    if (!kakaoKey) {
+      return alert("VITE_KAKAO_JS_KEY가 설정되어 있지 않습니다.");
+    }
     if (!window.Kakao.isInitialized()) {
-      window.Kakao.init(import.meta.env.VITE_KAKAO_JS_KEY);
+      window.Kakao.init(kakaoKey);
     }
     window.Kakao.Auth.login({
       success: (authObj: KakaoAuthSuccessResponse) => {

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -64,8 +64,7 @@ export function SignupDialog({
 
   const handleSocialLogin = (provider: "google" | "kakao") => {
     const backendUrl = import.meta.env.VITE_API_URL;
-    // TODO: url 수정 예정
-    window.location.href = `${backendUrl}/auth/social/${provider}`;
+    window.location.href = `${backendUrl}/oauth2/authorization/${provider}`;
   };
 
   const onSubmit = (formData: SignupFormValues) => {

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -60,9 +60,9 @@ export function SignupDialog({
     }
   }, [isOpen, reset]);
 
-  const handleSocialSignup = (provider: string) => {
-    console.log(`Signup with ${provider}`);
-    alert("가입 완료되었습니다.");
+  const handleSocialLogin = async (provider: "google" | "kakao") => {
+    // TODO: postSocialLogin(provider, { accessToken })
+    alert(`${provider} 로그인은 백엔드 배포 후 연동 예정입니다`);
     onClose();
   };
 
@@ -142,7 +142,7 @@ export function SignupDialog({
               type="button"
               variant="outline"
               className="w-full h-12 text-base cursor-pointer"
-              onClick={() => handleSocialSignup("google")}
+              onClick={() => handleSocialLogin("google")}
             >
               <img
                 src="/icons/google.svg"
@@ -156,7 +156,7 @@ export function SignupDialog({
               type="button"
               variant="outline"
               className="w-full h-12 text-base bg-[#FEE500] hover:bg-[#E6CF00] border-0 cursor-pointer text-black"
-              onClick={() => handleSocialSignup("kakao")}
+              onClick={() => handleSocialLogin("kakao")}
             >
               <img
                 src="/icons/kakao.svg"

--- a/src/components/auth/signup.schema.ts
+++ b/src/components/auth/signup.schema.ts
@@ -2,6 +2,8 @@ import z from "zod";
 
 export const signupSchema = z
   .object({
+    role: z.enum(["customer", "owner"]).default("customer"),
+
     name: z.string().min(1, "이름을 입력하세요."),
 
     email: z
@@ -12,7 +14,7 @@ export const signupSchema = z
     phone: z
       .string()
       .min(1, { message: "휴대폰 번호를 입력해주세요." })
-      .regex(/^010\d{8}$/, {
+      .regex(/^\d{2,3}-\d{3,4}-\d{4}$/, {
         message: "올바른 휴대폰 번호 형식이 아닙니다.",
       }),
 

--- a/src/components/auth/signup.schema.ts
+++ b/src/components/auth/signup.schema.ts
@@ -14,6 +14,7 @@ export const signupSchema = z
     phone: z
       .string()
       .min(1, { message: "휴대폰 번호를 입력해주세요." })
+      // SignupDialog에서 phoneNumber 유틸을 통해 하이픈 강제 적용되므로, 데이터 일관성을 위해 엄격한 정규식을 유지
       .regex(/^\d{2,3}-\d{3,4}-\d{4}$/, {
         message: "올바른 휴대폰 번호 형식이 아닙니다.",
       }),

--- a/src/components/auth/signup.schema.ts
+++ b/src/components/auth/signup.schema.ts
@@ -2,8 +2,6 @@ import z from "zod";
 
 export const signupSchema = z
   .object({
-    role: z.enum(["customer", "owner"]).default("customer"),
-
     name: z.string().min(1, "이름을 입력하세요."),
 
     email: z
@@ -11,34 +9,61 @@ export const signupSchema = z
       .min(1, { message: "이메일을 입력해주세요." })
       .email({ message: "올바른 이메일 형식이 아닙니다." }),
 
-    phone: z
+    phoneNumber: z
       .string()
       .min(1, { message: "휴대폰 번호를 입력해주세요." })
-      // SignupDialog에서 phoneNumber 유틸을 통해 하이픈 강제 적용되므로, 데이터 일관성을 위해 엄격한 정규식을 유지
-      .regex(/^\d{2,3}-\d{3,4}-\d{4}$/, {
-        message: "올바른 휴대폰 번호 형식이 아닙니다.",
-      }),
+      .refine(
+        (value) => {
+          const digits = value.replace(/\D/g, "");
+          return /^010\d{8}$/.test(digits);
+        },
+        {
+          message: "휴대폰 번호는 010으로 시작하는 11자리 숫자여야 합니다.",
+        },
+      ),
 
     password: z
       .string()
       .min(1, { message: "비밀번호를 입력해주세요." })
-      .min(8, { message: "비밀번호는 8자 이상이어야 합니다." }),
+      .min(8, { message: "비밀번호는 8자 이상이어야 합니다." })
+      .max(20, { message: "비밀번호는 20자 이하여야 합니다." })
+      .regex(/^[a-zA-Z0-9!@#$%^&*]+$/, {
+        message:
+          "비밀번호는 영문, 숫자, 특수문자(! @ # $ % ^ & *)만 사용 가능합니다.",
+      })
+      .refine(
+        (value) => {
+          const hasLetter = /[a-zA-Z]/.test(value);
+          const hasNumber = /\d/.test(value);
+          const hasSpecial = /[!@#$%^&*]/.test(value);
 
-    confirmPassword: z.string().min(1, "비밀번호를 다시 입력하세요."),
+          const validCount = [hasLetter, hasNumber, hasSpecial].filter(
+            (v) => v,
+          ).length;
 
-    terms: z.boolean().refine((v) => v === true, {
+          return validCount >= 2;
+        },
+        {
+          message:
+            "비밀번호는 영문, 숫자, 특수문자(! @ # $ % ^ & *) 중 최소 2가지 이상을 조합해야 합니다.",
+        },
+      ),
+
+    passwordConfirm: z.string().min(1, "비밀번호를 다시 입력하세요."),
+
+    tosConsent: z.boolean().refine((v) => v === true, {
       message: "필수 약관에 동의해주세요.",
     }),
 
-    privacy: z
+    privacyConsent: z
       .boolean()
       .refine((v) => v === true, { message: "필수 약관에 동의해주세요." }),
 
-    marketing: z.boolean().default(false),
+    marketingConsent: z.boolean().default(false),
   })
-  .refine((data) => data.password === data.confirmPassword, {
+  .refine((data) => data.password === data.passwordConfirm, {
     message: "비밀번호가 일치하지 않습니다.",
-    path: ["confirmPassword"],
+    path: ["passwordConfirm"],
   });
 
 export type SignupFormValues = z.input<typeof signupSchema>;

--- a/src/components/main/Header.tsx
+++ b/src/components/main/Header.tsx
@@ -5,6 +5,7 @@ import { Button } from "../ui/button";
 import { Link, useNavigate } from "react-router-dom";
 import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useAuthActions, useIsAuthenticated } from "@/stores/useAuthStore";
 
 type NavItem = {
   label: string;
@@ -17,6 +18,10 @@ export default function Header() {
 
   const [loginOpen, setLoginOpen] = useState(false);
   const [signupOpen, setSignupOpen] = useState(false);
+
+  const isAuthenticated = useIsAuthenticated();
+
+  const { logout } = useAuthActions();
 
   const nav = useNavigate();
 
@@ -57,6 +62,16 @@ export default function Header() {
     };
   }, [mobileOpen]);
 
+  const handleLogout = () => {
+    if (!confirm("로그아웃 하시겠습니까?")) return;
+
+    logout();
+    setMobileOpen(false);
+
+    alert("로그아웃 되었습니다.");
+    nav("/", { replace: true });
+  };
+
   const go = (to: string) => {
     setMobileOpen(false);
     nav(to);
@@ -90,24 +105,13 @@ export default function Header() {
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-20">
-          <Link
-            to="/"
-            className="flex items-center gap-2"
-            onClick={() => setMobileOpen(false)}
-            aria-label="홈으로 이동"
+          <button
+            type="button"
+            onClick={() => go("/")}
+            className={`text-[24px] tracking-tight ${brandClass}`}
           >
-            <img
-              src="/eatsfineLogo.svg"
-              alt="잇츠파인 로고"
-              className="h-7 w-7 shrink-0"
-            />
-            <span
-              className={`text-[24px] tracking-tight ${brandClass} hover:text-white/70 transition`}
-            >
-              잇츠파인
-            </span>
-          </Link>
-
+            잇츠파인
+          </button>
           <nav className="hidden lg:flex items-center gap-8 whitespace-nowrap">
             {navItems.map((item) => (
               <Link
@@ -120,26 +124,40 @@ export default function Header() {
             ))}
           </nav>
           <div className="hidden lg:flex items-center gap-3 whitespace-nowrap">
-            <Button
-              variant="ghost"
-              onClick={() => nav("/mypage")}
-              className={ghostBtnClass}
-            >
-              마이페이지
-            </Button>
-            <Button
-              variant="ghost"
-              onClick={() => setLoginOpen(true)}
-              className={ghostBtnClass}
-            >
-              로그인
-            </Button>
-            <Button
-              onClick={() => setSignupOpen(true)}
-              className={signupBtnClass}
-            >
-              회원가입
-            </Button>
+            {isAuthenticated ? (
+              <>
+                <Button
+                  variant="ghost"
+                  onClick={() => nav("/mypage")}
+                  className={ghostBtnClass}
+                >
+                  마이페이지
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={handleLogout}
+                  className={ghostBtnClass}
+                >
+                  로그아웃
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  variant="ghost"
+                  onClick={() => setLoginOpen(true)}
+                  className={ghostBtnClass}
+                >
+                  로그인
+                </Button>
+                <Button
+                  onClick={() => setSignupOpen(true)}
+                  className={signupBtnClass}
+                >
+                  회원가입
+                </Button>
+              </>
+            )}
           </div>
           <button
             type="button"
@@ -187,34 +205,46 @@ export default function Header() {
                   </button>
                 ))}
               </div>
-              <Button
-                variant="ghost"
-                className="text-lg h-12 mt-2 w-full cursor-pointer rounded-xl bg-black/5 hover:bg-black/10 transition-colors"
-                onClick={() => go("/mypage")}
-              >
-                마이페이지
-              </Button>
-              <div className="mt-3 grid grid-cols-2 gap-3">
-                <Button
-                  variant="outline"
-                  className="text-lg h-12 w-full cursor-pointer rounded-xl border-black/15 transition-colors"
-                  onClick={() => {
-                    setMobileOpen(false);
-                    setLoginOpen(true);
-                  }}
-                >
-                  로그인
-                </Button>
-                <Button
-                  className="text-lg h-12 w-full cursor-pointer rounded-xl bg-[#2196F3] hover:bg-[#1E88E5] transition-colors"
-                  onClick={() => {
-                    setMobileOpen(false);
-                    setSignupOpen(true);
-                  }}
-                >
-                  회원가입
-                </Button>
-              </div>
+              {isAuthenticated ? (
+                <div className="mt-3 grid grid-cols-2 gap-3">
+                  <Button
+                    variant="ghost"
+                    className="text-lg h-12 w-full cursor-pointer rounded-xl bg-black/5 hover:bg-black/10 transition-colors"
+                    onClick={() => go("/mypage")}
+                  >
+                    마이페이지
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    className="text-lg text-white h-12 w-full cursor-pointer rounded-xl bg-red-400 hover:bg-red-500 hover:text-white transition-colors"
+                    onClick={handleLogout}
+                  >
+                    로그아웃
+                  </Button>
+                </div>
+              ) : (
+                <div className="mt-3 grid grid-cols-2 gap-3">
+                  <Button
+                    variant="outline"
+                    className="text-lg h-12 w-full cursor-pointer rounded-xl border-black/15 transition-colors"
+                    onClick={() => {
+                      setMobileOpen(false);
+                      setLoginOpen(true);
+                    }}
+                  >
+                    로그인
+                  </Button>
+                  <Button
+                    className="text-lg h-12 w-full cursor-pointer rounded-xl bg-[#2196F3] hover:bg-[#1E88E5] transition-colors"
+                    onClick={() => {
+                      setMobileOpen(false);
+                      setSignupOpen(true);
+                    }}
+                  >
+                    회원가입
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/main/Header.tsx
+++ b/src/components/main/Header.tsx
@@ -5,7 +5,8 @@ import { Button } from "../ui/button";
 import { Link, useNavigate } from "react-router-dom";
 import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useAuthActions, useIsAuthenticated } from "@/stores/useAuthStore";
+import { useIsAuthenticated } from "@/stores/useAuthStore";
+import { logout } from "@/api/auth";
 
 type NavItem = {
   label: string;
@@ -20,8 +21,6 @@ export default function Header() {
   const [signupOpen, setSignupOpen] = useState(false);
 
   const isAuthenticated = useIsAuthenticated();
-
-  const { logout } = useAuthActions();
 
   const nav = useNavigate();
 
@@ -62,10 +61,10 @@ export default function Header() {
     };
   }, [mobileOpen]);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     if (!confirm("로그아웃 하시겠습니까?")) return;
 
-    logout();
+    await logout();
     setMobileOpen(false);
 
     alert("로그아웃 되었습니다.");

--- a/src/hooks/queries/useAuth.ts
+++ b/src/hooks/queries/useAuth.ts
@@ -2,13 +2,13 @@ import { postLogin, postSignup } from "@/api/auth";
 import type { LoginFormValues } from "@/components/auth/login.schema";
 import type { SignupFormValues } from "@/components/auth/signup.schema";
 import { useAuthActions } from "@/stores/useAuthStore";
-import type { ApiError } from "@/types/api";
+import type { ResponseLoginDto, ResponseSignupDto } from "@/types/auth";
 import { useMutation } from "@tanstack/react-query";
 
 // 이메일 회원가입 훅
 export const useEmailSignup = () => {
-  return useMutation({
-    mutationFn: (data: SignupFormValues) => {
+  return useMutation<ResponseSignupDto, Error, SignupFormValues>({
+    mutationFn: (data) => {
       const requestBody = {
         ...data,
         phoneNumber: data.phoneNumber.replace(/-/g, ""),
@@ -16,7 +16,7 @@ export const useEmailSignup = () => {
       };
       return postSignup(requestBody);
     },
-    onError: (error: ApiError) => {
+    onError: (error) => {
       console.error("회원가입 실패:", error);
     },
   });
@@ -26,12 +26,12 @@ export const useEmailSignup = () => {
 export const useEmailLogin = () => {
   const { login } = useAuthActions();
 
-  return useMutation({
+  return useMutation<ResponseLoginDto, Error, LoginFormValues>({
     mutationFn: (data: LoginFormValues) => postLogin(data),
     onSuccess: (response) => {
       login(response.accessToken);
     },
-    onError: (error: ApiError) => {
+    onError: (error) => {
       console.error("이메일 로그인 실패:", error);
     },
   });

--- a/src/hooks/queries/useAuth.ts
+++ b/src/hooks/queries/useAuth.ts
@@ -1,4 +1,4 @@
-import { postLogin, postSignup, postSocialLogin } from "@/api/auth";
+import { postLogin, postSignup } from "@/api/auth";
 import type { LoginFormValues } from "@/components/auth/login.schema";
 import type { SignupFormValues } from "@/components/auth/signup.schema";
 import { useAuthActions } from "@/stores/useAuthStore";
@@ -35,27 +35,6 @@ export const useEmailLogin = () => {
     },
     onError: (error: ApiError) => {
       console.error("이메일 로그인 실패:", error);
-    },
-  });
-};
-
-// 소셜 로그인 훅
-export const useSocialLogin = () => {
-  const { login } = useAuthActions();
-
-  return useMutation({
-    mutationFn: ({
-      provider,
-      token,
-    }: {
-      provider: "google" | "kakao";
-      token: string;
-    }) => postSocialLogin(provider, { accessToken: token }),
-    onSuccess: (response) => {
-      login(response.data.accessToken);
-    },
-    onError: (error: ApiError) => {
-      console.error("소셜 로그인 실패:", error);
     },
   });
 };

--- a/src/hooks/queries/useAuth.ts
+++ b/src/hooks/queries/useAuth.ts
@@ -10,7 +10,7 @@ export const useEmailSignup = () => {
   return useMutation({
     mutationFn: (data: SignupFormValues) => {
       const requestBody = {
-        role: data.role!,
+        role: "customer" as const,
         name: data.name,
         email: data.email,
         phone: data.phone,

--- a/src/hooks/queries/useAuth.ts
+++ b/src/hooks/queries/useAuth.ts
@@ -10,11 +10,9 @@ export const useEmailSignup = () => {
   return useMutation({
     mutationFn: (data: SignupFormValues) => {
       const requestBody = {
-        role: "customer" as const,
-        name: data.name,
-        email: data.email,
-        phone: data.phone,
-        password: data.password,
+        ...data,
+        phoneNumber: data.phoneNumber.replace(/-/g, ""),
+        marketingConsent: data.marketingConsent ?? false,
       };
       return postSignup(requestBody);
     },
@@ -31,7 +29,7 @@ export const useEmailLogin = () => {
   return useMutation({
     mutationFn: (data: LoginFormValues) => postLogin(data),
     onSuccess: (response) => {
-      login(response.data.accessToken);
+      login(response.accessToken);
     },
     onError: (error: ApiError) => {
       console.error("이메일 로그인 실패:", error);

--- a/src/hooks/queries/useAuth.ts
+++ b/src/hooks/queries/useAuth.ts
@@ -1,0 +1,61 @@
+import { postLogin, postSignup, postSocialLogin } from "@/api/auth";
+import type { LoginFormValues } from "@/components/auth/login.schema";
+import type { SignupFormValues } from "@/components/auth/signup.schema";
+import { useAuthActions } from "@/stores/useAuthStore";
+import type { ApiError } from "@/types/api";
+import { useMutation } from "@tanstack/react-query";
+
+// 이메일 회원가입 훅
+export const useEmailSignup = () => {
+  return useMutation({
+    mutationFn: (data: SignupFormValues) => {
+      const requestBody = {
+        role: data.role!,
+        name: data.name,
+        email: data.email,
+        phone: data.phone,
+        password: data.password,
+      };
+      return postSignup(requestBody);
+    },
+    onError: (error: ApiError) => {
+      console.error("회원가입 실패:", error);
+    },
+  });
+};
+
+// 이메일 로그인 훅
+export const useEmailLogin = () => {
+  const { login } = useAuthActions();
+
+  return useMutation({
+    mutationFn: (data: LoginFormValues) => postLogin(data),
+    onSuccess: (response) => {
+      login(response.data.accessToken);
+    },
+    onError: (error: ApiError) => {
+      console.error("이메일 로그인 실패:", error);
+    },
+  });
+};
+
+// 소셜 로그인 훅
+export const useSocialLogin = () => {
+  const { login } = useAuthActions();
+
+  return useMutation({
+    mutationFn: ({
+      provider,
+      token,
+    }: {
+      provider: "google" | "kakao";
+      token: string;
+    }) => postSocialLogin(provider, { accessToken: token }),
+    onSuccess: (response) => {
+      login(response.data.accessToken);
+    },
+    onError: (error: ApiError) => {
+      console.error("소셜 로그인 실패:", error);
+    },
+  });
+};

--- a/src/layouts/PublicLayout.tsx
+++ b/src/layouts/PublicLayout.tsx
@@ -1,15 +1,15 @@
-import { useAuthActions, useIsAuthenticated } from "@/stores/useAuthStore";
+import { logout } from "@/api/auth";
+import { useIsAuthenticated } from "@/stores/useAuthStore";
 import { Link, Outlet, useNavigate } from "react-router-dom";
 
 export default function PublicLayout() {
   const nav = useNavigate();
-  const { logout } = useAuthActions();
   const isAuthenticated = useIsAuthenticated();
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     if (!confirm("로그아웃 하시겠습니까?")) return;
 
-    logout();
+    await logout();
     alert("로그아웃 되었습니다.");
     nav("/", { replace: true });
   };

--- a/src/layouts/PublicLayout.tsx
+++ b/src/layouts/PublicLayout.tsx
@@ -1,10 +1,19 @@
-import { Link, Outlet } from "react-router-dom";
+import { useAuthActions, useIsAuthenticated } from "@/stores/useAuthStore";
+import { Link, Outlet, useNavigate } from "react-router-dom";
 
-type PublicLayoutProps = {
-  onLogOut?: () => void;
-};
+export default function PublicLayout() {
+  const nav = useNavigate();
+  const { logout } = useAuthActions();
+  const isAuthenticated = useIsAuthenticated();
 
-export default function PublicLayout({ onLogOut }: PublicLayoutProps) {
+  const handleLogout = () => {
+    if (!confirm("로그아웃 하시겠습니까?")) return;
+
+    logout();
+    alert("로그아웃 되었습니다.");
+    nav("/", { replace: true });
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="w-full border-b bg-white sticky top-0 z-40 py-2">
@@ -20,13 +29,15 @@ export default function PublicLayout({ onLogOut }: PublicLayoutProps) {
               <p className="text-xs">원하는 자리를 선택하는 스마트 식당 예약</p>
             </div>
           </Link>
-          <button
-            type="button"
-            onClick={onLogOut}
-            className="flex items-center gap-2 px-4 py-2 text-black hover:text-gray-600 transition cursor-pointer"
-          >
-            로그아웃
-          </button>
+          {isAuthenticated && (
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="flex items-center gap-2 px-4 py-2 text-black hover:text-gray-600 transition cursor-pointer"
+            >
+              로그아웃
+            </button>
+          )}
         </div>
       </header>
       <main className="max-w-7xl mx-auto px-4 py-8">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,14 @@ import "./index.css";
 import App from "./App.tsx";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/query/queryClient.ts";
+import { GoogleOAuthProvider } from "@react-oauth/google";
 
 createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
-  </StrictMode>,
+  <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </StrictMode>
+  </GoogleOAuthProvider>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,8 +6,14 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/query/queryClient.ts";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 
+const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+
+if (!googleClientId) {
+  throw new Error("VITE_GOOGLE_CLIENT_ID is required");
+}
+
 createRoot(document.getElementById("root")!).render(
-  <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+  <GoogleOAuthProvider clientId={googleClientId}>
     <StrictMode>
       <QueryClientProvider client={queryClient}>
         <App />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,20 +4,11 @@ import "./index.css";
 import App from "./App.tsx";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/query/queryClient.ts";
-import { GoogleOAuthProvider } from "@react-oauth/google";
-
-const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
-
-if (!googleClientId) {
-  throw new Error("VITE_GOOGLE_CLIENT_ID is required");
-}
 
 createRoot(document.getElementById("root")!).render(
-  <GoogleOAuthProvider clientId={googleClientId}>
-    <StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    </StrictMode>
-  </GoogleOAuthProvider>,
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </StrictMode>,
 );

--- a/src/pages/LoginErrorPage.tsx
+++ b/src/pages/LoginErrorPage.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { AlertCircle, Home } from "lucide-react";
+
+const LoginErrorPage: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-6">
+      <div className="max-w-md w-full text-center">
+        {/* 아이콘 섹션 (Red Theme) */}
+        <div className="relative mb-8">
+          <div className="absolute inset-0 flex items-center justify-center animate-pulse">
+            <div className="w-32 h-32 bg-red-100 rounded-full"></div>
+          </div>
+          <div className="relative flex justify-center">
+            <AlertCircle size={60} className="text-red-600" />
+          </div>
+        </div>
+
+        {/* 텍스트 섹션 */}
+        <h1 className="text-5xl font-bold text-red-600 mb-4">Error</h1>
+        <h2 className="text-2xl font-semibold text-gray-900 mb-3">
+          로그인에 실패했습니다
+        </h2>
+        <p className="text-gray-500 mb-10 leading-relaxed">
+          소셜 로그인 연결 중 문제가 발생했습니다.
+          <br />
+          네트워크 상태를 확인하거나 다시 시도해 주세요.
+        </p>
+
+        {/* 버튼 섹션 */}
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <button
+            onClick={() => navigate("/", { replace: true })}
+            className="cursor-pointer flex items-center justify-center gap-2 px-6 py-3 border border-gray-300 rounded-xl bg-white text-gray-700 font-medium hover:bg-gray-50 transition-all active:scale-95"
+          >
+            <Home size={18} />
+            홈으로 이동
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginErrorPage;

--- a/src/pages/OAuthCallbackPage.tsx
+++ b/src/pages/OAuthCallbackPage.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Loader2 } from 'lucide-react'; // 로딩 아이콘
+import { useAuthActions } from '@/stores/useAuthStore';
+
+const OAuthCallbackPage: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { login } = useAuthActions();
+
+  useEffect(() => {
+    const accessToken = searchParams.get('accessToken');
+
+    if (accessToken) {
+      login(accessToken);
+      navigate('/', { replace: true });
+    } else {
+      navigate('/login/error', { replace: true });
+    }
+  }, [searchParams, navigate, login]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-6">
+      <div className="max-w-md w-full text-center">
+        {/* 아이콘 섹션 */}
+        <div className="relative mb-10">
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="w-32 h-32 bg-blue-100 rounded-full"></div>
+          </div>
+          <div className="relative flex justify-center">
+            <Loader2 size={60} className="text-blue-600 animate-spin" />
+          </div>
+        </div>
+
+        {/* 텍스트 섹션 */}
+        <h2 className="text-2xl font-semibold text-gray-900 mb-4">
+          로그인 처리 중...
+        </h2>
+        <p className="text-gray-500 leading-relaxed">
+          잠시만 기다려 주시면<br />
+          메인 화면으로 이동합니다.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default OAuthCallbackPage;

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import { immer } from "zustand/middleware/immer";
+
+interface AuthState {
+  accessToken: string | null;
+  isAuthenticated: boolean;
+
+  actions: {
+    login: (token: string) => void;
+    logout: () => void;
+  };
+}
+
+export const useAuthStore = create<AuthState>()(
+  // persist: 내용물이 바뀌면 무조건 저장소에 기록
+  persist(
+    immer((set) => ({
+      accessToken: null,
+      isAuthenticated: false,
+
+      actions: {
+        login: (token) =>
+          set((state) => {
+            state.accessToken = token;
+            state.isAuthenticated = true;
+          }),
+        logout: () =>
+          set((state) => {
+            state.accessToken = null;
+            state.isAuthenticated = false;
+          }),
+      },
+    })),
+    {
+      name: "auth-storage",
+      storage: createJSONStorage(() => localStorage),
+      // persist가 저장할 때 state만 저장하도록 설정
+      partialize: (state) => ({
+        accessToken: state.accessToken,
+        isAuthenticated: state.isAuthenticated,
+      }),
+    },
+  ),
+);
+
+export const useAuthActions = () => useAuthStore((state) => state.actions);
+export const useAuthToken = () => useAuthStore((state) => state.accessToken);
+export const useIsAuthenticated = () =>
+  useAuthStore((state) => state.isAuthenticated);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,12 +1,12 @@
-  export interface ApiResponse<T> {
-    success: boolean;
-    code: string;
-    data: T;
-    message: string;
-  }
+export interface ApiResponse<T> {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: T;
+}
 
-  export interface ApiError {
-    status: number;
-    code?: string;
-    message: string;
-  }
+export interface ApiError {
+  status: number;
+  code?: string;
+  message: string;
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,35 @@
+export type RequestSignupDto = {
+  email: string;
+  password: string;
+  name: string;
+  phone: string;
+  role: "customer" | "owner";
+};
+
+export type ResponseSignupDto = {
+  userId: string;
+  email: string;
+  name: string;
+  role: "customer" | "owner";
+};
+
+export type RequestLoginDto = {
+  email: string;
+  password: string;
+};
+
+export type ResponseLoginDto = {
+  accessToken: string;
+  user: {
+    userId: string;
+    email: string;
+    name: string;
+    role: "customer" | "owner";
+  };
+};
+
+export type ResponseLogoutDto = null;
+
+export type ResponseRefreshDto = {
+  accessToken: string;
+};

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -28,10 +28,6 @@ export type ResponseLoginDto = {
   };
 };
 
-export type RequestSocialLoginDto = {
-  accessToken: string;
-};
-
 export type ResponseLogoutDto = null;
 
 export type ResponseRefreshDto = {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,16 +1,17 @@
 export type RequestSignupDto = {
+  name: string;
   email: string;
   password: string;
-  name: string;
-  phone: string;
-  role: "customer" | "owner";
+  passwordConfirm: string;
+  phoneNumber: string;
+  tosConsent: boolean;
+  privacyConsent: boolean;
+  marketingConsent: boolean;
 };
 
 export type ResponseSignupDto = {
-  userId: string;
-  email: string;
-  name: string;
-  role: "customer" | "owner";
+  id: number;
+  createdAt: string;
 };
 
 export type RequestLoginDto = {
@@ -19,16 +20,12 @@ export type RequestLoginDto = {
 };
 
 export type ResponseLoginDto = {
+  id: number;
   accessToken: string;
-  user: {
-    userId: string;
-    email: string;
-    name: string;
-    role: "customer" | "owner";
-  };
+  refreshToken: string;
 };
 
-export type ResponseLogoutDto = null;
+export type ResponseLogoutDto = string;
 
 export type ResponseRefreshDto = {
   accessToken: string;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -28,6 +28,10 @@ export type ResponseLoginDto = {
   };
 };
 
+export type RequestSocialLoginDto = {
+  accessToken: string;
+};
+
 export type ResponseLogoutDto = null;
 
 export type ResponseRefreshDto = {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -22,7 +22,7 @@ export type RequestLoginDto = {
 export type ResponseLoginDto = {
   id: number;
   accessToken: string;
-  refreshToken: string;
+  refreshToken: string | null;
 };
 
 export type ResponseLogoutDto = string;

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+export const getErrorMessage = (error: unknown): string => {
+  // Axios 에러인 경우 (서버에서 준 response.data.message가 있으면 사용)
+  if (axios.isAxiosError(error)) {
+    return error.response?.data?.message || error.message;
+  }
+
+  //ApiError 객체인 경우
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+
+  // 일반 JS 에러인 경우
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  // 그 외
+  return "알 수 없는 오류가 발생했습니다.";
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,3 +10,8 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+interface Window {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Kakao: any;
+}


### PR DESCRIPTION
## 🚨변경사항
백엔드 API 명세 반영 및 토큰 재발급 로직 구현을 위해 src/api/axios.ts 등 **공용 코드가 업데이트**되었습니다.
아래 3가지 변경 사항을 꼭 확인 부탁드립니다.


**1. 토큰 관리 방식 변경**
- 기존: localStorage에서 accessToken 직접 사용
- 변경: Zustand Store(useAuthStore)를 통해 토큰 관리

**2. 에러 핸들링 방식 조정**
- 현재는 401 / isSuccess === false만 ApiError로, 그 외는 AxiosError를 유지
- 두 타입을 구분할 필요 없이, 통일된 서버 메시지를 사용할 수 있도록 **에러 처리 유틸** 함수 구현
- alert(getErrorMessage(error)); 이런 형식으로 사용하시면 됩니다!

**3. 변경 및 추가된 기능**
- Swagger UI 반영
  - success → isSuccess
  - /auth/refresh → /api/auth/reissue
- 자동 토큰 재발급
  · 401 에러 발생 시 인터셉터가 자동으로 재발급 시도
  · 성공 시 실패했던 요청 자동 재시도 / 실패 시 자동 로그아웃

## 💡 개요
로그인 / 회원가입 API 연동

## 🔢 관련 이슈 링크
- Closes #47 

## 💻 작업내용
- **UI/UX**
  - 회원가입 모달 내 Role(사장/고객) 선택 버튼 UI 추가
  - 로그인 상태에 따른 헤더 UI 분기 처리 (로그인/회원가입 ↔ 마이페이지/로그아웃)

- **API 연동**
  - 이메일 로그인/회원가입 API 연동 
  - 소셜(구글, 카카오) 로그인 API 연동

- **상태 관리**
  - Zustand 도입: 인증 정보(`accessToken`, `isAuthenticated`) 전역 관리
  - Persist Middleware 적용: 브라우저 새로고침 후에도 로그인 상태 유지
  - 로그아웃 로직 구현

- **현재 배포 서버에 인증 API가 반영되지 않아 실제 로그인, 회원가입 시 오류가 발생하는 것이 정상입니다.**
(추후 서버 배포 완료 시 연동 테스트 예정)

- **로그인 후의 UI를 확인하시려면, 개발자 도구(F12) 콘솔에 아래 코드를 한 번에 복붙 입력하여 
임시 로그인 상태로 전환하실 수 있습니다.**
localStorage.setItem('auth-storage', '{"state":{"accessToken":"fake-test-token","isAuthenticated":true},"version":0}'); location.reload();

- 현재 API 명세서에 `아이디/비밀번호 찾기` 기능이 없습니다. 
이번 MVP 스펙에서 제외되는 것인지 팀장님께 먼저 확인받은 뒤에 작업 진행할 예정입니다!

## 📌 변경사항PR
- [x] FEAT: 새로운 기능 추가
- [ ] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [x] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
- **소셜 로그인 약관 처리**
이용약관 구현하는 것이 매우 복잡해질 것 같아  `소셜 계정으로 가입 시 이용약관, 개인정보처리방침에 동의하는 것으로 간주합니다.` 
라는 문구를 추가하는 방식으로 처리했습니다. 이대로 진행해도 괜찮을까요?

- **개발 우선순위**
로그인한 사용자만 접근 가능한 경로 설정(Route Guard)은 별도 PR로 분리할 생각입니다. 
경로 설정을 먼저 마무리하는 것이 좋을지, 아니면 새 가게 등록 API 연동 작업을 진행하는 것이 좋을지 의견 부탁드립니다.
경로 설정을 먼저 적용할 경우 마이페이지나 내가게관리 페이지 접근 시 반드시 로그인이 필요해져 다소 번거로울 수 있을 것 같습니다

- **비로그인 시 헤더 메뉴 처리 방식**
로그인을 안 했을 때 로그인이 필수인 메뉴(ex:내 가게 관리)를 헤더에서 어떻게 처리하면 좋을까요?
A안: 아예 버튼을 숨김 
B안: 버튼은 보여주되, 클릭 시 로그인 모달을 띄움 
어떤 방식이 UX적으로 더 적절할지 의견 부탁드립니다.
이 부분은 경로 설정과 함께 하나의 PR로 올리겠습니다.


## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 이메일 회원가입·로그인, 소셜(OAuth) 로그인 연동 및 콜백 처리 페이지 추가
  * 로그인 오류 화면과 진행 상태 표시(로그인 처리 중) 추가

* **Refactor**
  * 중앙화된 인증 상태 관리(영속화) 도입 및 헤더/레이아웃의 인증 기반 UI 전환
  * API 요청에 자동 토큰 갱신/재시도 로직 추가 및 인증 흐름 개선
  * 회원가입/로그인 폼 검증·입력 흐름 및 UX 개선

* **Other**
  * 사용자 친화적 오류 메시지 유틸 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->