### PR TITLE
feat: 내가게관리 메뉴관리 API 연동

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -5,7 +5,6 @@ import { clearAuth, postRefresh } from "./auth";
 import { useAuthStore } from "@/stores/useAuthStore";
 
 
-export const OWNER_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJvd25lckBuYXZlci5jb20iLCJyb2xlIjoiUk9MRV9PV05FUiIsImlhdCI6MTc3MDU3MDE5NywiZXhwIjo0OTI0MTcwMTk3fQ.0O8-mHTT6j59VTuMYmtGZs4r7JvqlsRi0jU09601iKs";
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL as string | undefined,
   timeout: 10000,
@@ -18,7 +17,7 @@ function getAccessToken() {
 api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const token = getAccessToken();
   if (token) {
-    config.headers.Authorization = `Bearer ${OWNER_TOKEN}`;
+    config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -4,7 +4,6 @@ import type { ApiError } from "@/types/api";
 import { clearAuth, postRefresh } from "./auth";
 import { useAuthStore } from "@/stores/useAuthStore";
 
-
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL as string | undefined,
   timeout: 10000,

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -4,6 +4,8 @@ import type { ApiError } from "@/types/api";
 import { clearAuth, postRefresh } from "./auth";
 import { useAuthStore } from "@/stores/useAuthStore";
 
+
+export const OWNER_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJvd25lckBuYXZlci5jb20iLCJyb2xlIjoiUk9MRV9PV05FUiIsImlhdCI6MTc3MDU3MDE5NywiZXhwIjo0OTI0MTcwMTk3fQ.0O8-mHTT6j59VTuMYmtGZs4r7JvqlsRi0jU09601iKs";
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL as string | undefined,
   timeout: 10000,
@@ -16,7 +18,7 @@ function getAccessToken() {
 api.interceptors.request.use((config: InternalAxiosRequestConfig) => {
   const token = getAccessToken();
   if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+    config.headers.Authorization = `Bearer ${OWNER_TOKEN}`;
   }
   return config;
 });

--- a/src/api/owner/menus.ts
+++ b/src/api/owner/menus.ts
@@ -62,9 +62,9 @@ export interface DeleteMenusRequest {
 }
 
 export interface DeleteMenusResponse {
-  success: boolean;
+  isSuccess: boolean;
   code: string;
-  data: { deletedMenuIds: number[] };
+  result: { deletedMenuIds: number[] };
   message: string;
 }
 

--- a/src/api/owner/menus.ts
+++ b/src/api/owner/menus.ts
@@ -1,0 +1,184 @@
+// src/api/owner/menus.ts
+import { api, OWNER_TOKEN } from "../axios"; // 프로젝트의 axios 인스턴스 경로에 맞춰 조정하세요
+import type { ApiResponse } from "@/types/api";
+
+export interface ServerMenu {
+  menuId: number;
+  name: string;
+  description?: string | null;
+  price: number;
+  category?: string | null;
+  imageUrl?: string | null;
+  isSoldOut?: boolean;
+  // 서버가 활성화 정보(isActive)를 주지 않으면 로컬에서 관리합니다.
+}
+
+interface GetMenusResult {
+  menus: ServerMenu[];
+}
+
+interface UploadImageResult {
+  imageKey: string;
+  imageUrl: string;
+}
+
+export interface MenuUpdateItem {
+  name: string;
+  description?: string;
+  price: number;
+  category: string;
+  imageKey?: string; // 빈 문자열 보내면 이미지 삭제
+}
+
+interface MenuUpdateResult {
+  menuId: number;
+  name: string;
+  description?: string;
+  price: number;
+  category?: string;
+  imageUrl?: string;
+}
+
+interface MenuCreateItem {
+  name: string;
+  description?: string;
+  price: number;
+  category: string;
+  imageKey?: string;
+}
+
+interface MenuCreateResult {
+  menus: {
+    menuId: number;
+    name: string;
+    description?: string;
+    price: number;
+    category?: string;
+    imageUrl?: string;
+    imageKey?: string;
+  }[];
+}
+
+export interface DeleteMenusRequest {
+  menuIds: number[];
+}
+
+export interface DeleteMenusResponse {
+  success: boolean;
+  code: string;
+  data: { deletedMenuIds: number[] };
+  message: string;
+}
+
+
+
+/**
+ * 가게의 메뉴 목록 조회
+ * @param storeId string or number
+ */
+export async function getMenus(storeId: string | number) {
+  const res = await api.get<ApiResponse<GetMenusResult>>(`/api/v1/stores/${storeId}/menus`);
+  return res.data;
+}
+
+export async function createMenus(storeId: string | number, menus: MenuCreateItem[]) {
+  const res = await api.post<ApiResponse<MenuCreateResult>>(
+    `/api/v1/stores/${storeId}/menus`,
+    { menus },{
+        headers: {
+            Authorization: `Bearer ${OWNER_TOKEN}`,
+        }
+    }
+  );
+  return res.data;
+}
+
+export async function uploadMenuImage(storeId: string | number, file: File) {
+  const formData = new FormData();
+  formData.append("image", file);
+
+  const token = localStorage.getItem("accessToken");
+
+  const res = await api.post<ApiResponse<{ imageKey: string; imageUrl: string }>>(
+    `/api/v1/stores/${storeId}/menus/images`,
+    formData,
+    { headers: {
+        Authorization: `Bearer ${OWNER_TOKEN}`,
+     } }
+  );
+  return res.data;
+}
+
+export const deleteMenuImage = async (
+  storeId: string,
+  menuId: string
+): Promise<ApiResponse<{ deletedImageKey: string }>> => {
+  try {
+    const res = await api.delete<ApiResponse<{ deletedImageKey: string }>>(
+        `/api/v1/stores/${storeId}/menus/${menuId}/image`,
+        {
+            headers: {
+                Authorization: `Bearer ${OWNER_TOKEN}`,
+            }
+        }
+    );
+    return res.data;
+  } catch (err: any) {
+    console.error('deleteMenuImage error', err);
+    return {
+      isSuccess: false,
+      code: '_MENU_IMAGE_DELETE_FAILED',
+      message: err?.response?.data?.message || '이미지 삭제 실패',
+      result: { deletedImageKey: '' },
+    };
+  }
+};
+
+export async function updateMenu(
+  storeId: string | number,
+  menuId: string | number,
+  menu: MenuUpdateItem
+) {
+  const res = await api.patch<ApiResponse<MenuUpdateResult>>(
+    `/api/v1/stores/${storeId}/menus/${menuId}`,
+    menu,
+    {
+      headers: {
+        Authorization: `Bearer ${OWNER_TOKEN}`,
+      },
+    }
+  );
+  return res.data;
+}
+
+export const deleteMenus = async (storeId: string, menuIds: number[]): Promise<DeleteMenusResponse> => {
+  const res = await api.delete(`/api/v1/stores/${storeId}/menus`, {
+    headers: {
+        Authorization: `Bearer ${OWNER_TOKEN}`,
+      },
+    data: { menuIds },
+  });
+
+  return res.data;
+};
+
+// 품절 상태 변경
+export async function updateMenuSoldOut(
+  storeId: string | number,
+  menuId: string | number,
+  isSoldOut: boolean
+) {
+  const body = { isSoldOut };
+  const res = await api.patch<ApiResponse<{ menuId: number; isSoldOut: boolean }>>(
+    `/api/v1/stores/${storeId}/menus/${menuId}/sold-out`,
+    body,
+    {
+      headers: {
+        Authorization: `Bearer ${OWNER_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  return res.data;
+}
+

--- a/src/api/owner/menus.ts
+++ b/src/api/owner/menus.ts
@@ -1,4 +1,4 @@
-import { api, OWNER_TOKEN } from "../axios";
+import { api} from "../axios";
 import type { ApiResponse } from "@/types/api";
 
 export interface ServerMenu {
@@ -76,11 +76,7 @@ export async function getMenus(storeId: string | number) {
 export async function createMenus(storeId: string | number, menus: MenuCreateItem[]) {
   const res = await api.post<ApiResponse<MenuCreateResult>>(
     `/api/v1/stores/${storeId}/menus`,
-    { menus },{
-        headers: {
-            Authorization: `Bearer ${OWNER_TOKEN}`,
-        }
-    }
+    { menus },
   );
   return res.data;
 }
@@ -89,14 +85,9 @@ export async function uploadMenuImage(storeId: string | number, file: File) {
   const formData = new FormData();
   formData.append("image", file);
 
-  const token = localStorage.getItem("accessToken");
-
   const res = await api.post<ApiResponse<{ imageKey: string; imageUrl: string }>>(
     `/api/v1/stores/${storeId}/menus/images`,
     formData,
-    { headers: {
-        Authorization: `Bearer ${OWNER_TOKEN}`,
-     } }
   );
   return res.data;
 }
@@ -108,11 +99,6 @@ export const deleteMenuImage = async (
   try {
     const res = await api.delete<ApiResponse<{ deletedImageKey: string }>>(
         `/api/v1/stores/${storeId}/menus/${menuId}/image`,
-        {
-            headers: {
-                Authorization: `Bearer ${OWNER_TOKEN}`,
-            }
-        }
     );
     return res.data;
   } catch (err: any) {
@@ -134,20 +120,12 @@ export async function updateMenu(
   const res = await api.patch<ApiResponse<MenuUpdateResult>>(
     `/api/v1/stores/${storeId}/menus/${menuId}`,
     menu,
-    {
-      headers: {
-        Authorization: `Bearer ${OWNER_TOKEN}`,
-      },
-    }
   );
   return res.data;
 }
 
 export const deleteMenus = async (storeId: string, menuIds: number[]): Promise<DeleteMenusResponse> => {
   const res = await api.delete(`/api/v1/stores/${storeId}/menus`, {
-    headers: {
-        Authorization: `Bearer ${OWNER_TOKEN}`,
-      },
     data: { menuIds },
   });
 
@@ -163,12 +141,6 @@ export async function updateMenuSoldOut(
   const res = await api.patch<ApiResponse<{ menuId: number; isSoldOut: boolean }>>(
     `/api/v1/stores/${storeId}/menus/${menuId}/sold-out`,
     body,
-    {
-      headers: {
-        Authorization: `Bearer ${OWNER_TOKEN}`,
-        "Content-Type": "application/json",
-      },
-    }
   );
   return res.data;
 }

--- a/src/api/owner/menus.ts
+++ b/src/api/owner/menus.ts
@@ -1,5 +1,4 @@
-// src/api/owner/menus.ts
-import { api, OWNER_TOKEN } from "../axios"; // 프로젝트의 axios 인스턴스 경로에 맞춰 조정하세요
+import { api, OWNER_TOKEN } from "../axios";
 import type { ApiResponse } from "@/types/api";
 
 export interface ServerMenu {
@@ -10,7 +9,6 @@ export interface ServerMenu {
   category?: string | null;
   imageUrl?: string | null;
   isSoldOut?: boolean;
-  // 서버가 활성화 정보(isActive)를 주지 않으면 로컬에서 관리합니다.
 }
 
 interface GetMenusResult {
@@ -27,7 +25,7 @@ export interface MenuUpdateItem {
   description?: string;
   price: number;
   category: string;
-  imageKey?: string; // 빈 문자열 보내면 이미지 삭제
+  imageKey?: string; 
 }
 
 interface MenuUpdateResult {
@@ -70,12 +68,6 @@ export interface DeleteMenusResponse {
   message: string;
 }
 
-
-
-/**
- * 가게의 메뉴 목록 조회
- * @param storeId string or number
- */
 export async function getMenus(storeId: string | number) {
   const res = await api.get<ApiResponse<GetMenusResult>>(`/api/v1/stores/${storeId}/menus`);
   return res.data;
@@ -162,7 +154,6 @@ export const deleteMenus = async (storeId: string, menuIds: number[]): Promise<D
   return res.data;
 };
 
-// 품절 상태 변경
 export async function updateMenuSoldOut(
   storeId: string | number,
   menuId: string | number,

--- a/src/components/owner/menuFormModal.tsx
+++ b/src/components/owner/menuFormModal.tsx
@@ -125,9 +125,9 @@ const [uploading, setUploading] = useState(false);
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm"
     onClick={onClose}>
-      <div className="bg-white w-full max-w-lg rounded-2xl shadow-2xl overflow-hidden animate-in fade-in zoom-in duration-200 border border-gray-100"
+      <div className="bg-white w-full max-w-lg rounded-2xl shadow-2xl flex flex-col overflow-hidden animate-in fade-in zoom-in duration-200 border border-gray-100"
       onClick={(e)=>e.stopPropagation()}>
-        <div className="flex justify-between items-center px-8 py-6 border-b border-gray-50">
+        <div className="flex justify-between items-center px-8 py-6 border-b border-gray-50 shrink-0">
           <h3 className="text-xl text-gray-900">
             {editingMenu ? '메뉴 수정' : '새 메뉴 등록'}
           </h3>
@@ -135,7 +135,7 @@ const [uploading, setUploading] = useState(false);
             <X size={20} />
           </button>
         </div>
-
+        <div className='flex-1 overflow-y-auto'>
         <div className="flex flex-col items-center gap-3 w-full">
           {imageUrl ? (
             <img
@@ -189,7 +189,7 @@ const [uploading, setUploading] = useState(false);
         {imageUrl && (
           <button
             type="button"
-            className="ml-2 px-4 py-2 bg-red-100 text-red-600 rounded-xl"
+            className="cursor-pointer ml-2 px-4 py-2 bg-red-100 text-red-600 rounded-xl"
             onClick={async () => {
               if (!editingMenu?.menuId) {
                 setImageFile(null);
@@ -224,6 +224,7 @@ const [uploading, setUploading] = useState(false);
             삭제
           </button>
         )}
+        </div>
         </div>
       </div>
 

--- a/src/components/owner/menuFormModal.tsx
+++ b/src/components/owner/menuFormModal.tsx
@@ -8,9 +8,9 @@ interface MenuFormModalProps {
   onClose: () => void;
   onSubmit: (menuData: any) => void;
   categories: { id: string; label: string }[];
-  editingMenu?: any; // 수정 시 전달받을 데이터
+  editingMenu?: any;
   storeId: string;
-  onImageDelete?: () => void; // 이미지 삭제 후 부모에게 알리기 위한 콜백
+  onImageDelete?: () => void;
 }
 
 
@@ -35,7 +35,6 @@ const [imageUrl, setImageUrl] = useState<string | null>(editingMenu?.imageUrl ||
 const [imageKey, setImageKey] = useState<string | null>(null);
 const [uploading, setUploading] = useState(false);
 
-  // 수정 모드일 경우 기존 데이터를 폼에 채워넣음
   useEffect(() => {
     if (editingMenu) {
       setFormData({
@@ -77,15 +76,12 @@ const [uploading, setUploading] = useState(false);
           price: Number(formData.price),
           category: formData.category,    };
     if (imageKey !== null) {
-      // 이미지 삭제 시 "", 새 업로드 시 "new_key"가 들어옴
       payload.imageKey = imageKey;
     } else if (isEditing && editingMenu?.imageKey) {
-      // imageKey가 null이고 수정모드면 기존 키 유지
       payload.imageKey = editingMenu.imageKey;
     }
 
     if (isEditing) {
-  // ✅ 단일 객체 전달
   const res = await updateMenu(storeId, editingMenu.id, payload);
   if (res.isSuccess) {
     alert("메뉴가 성공적으로 수정되었습니다.");
@@ -103,7 +99,6 @@ const [uploading, setUploading] = useState(false);
     alert("메뉴 수정 실패: " + res.message);
   }
 } else {
-  // 새 메뉴 생성
   const res = await createMenus(storeId, [payload]);
       if (res.isSuccess) {
         alert("메뉴 등록 성공!");
@@ -141,9 +136,7 @@ const [uploading, setUploading] = useState(false);
           </button>
         </div>
 
-        {/* 이미지 업로드 섹션 */}
         <div className="flex flex-col items-center gap-3 w-full">
-          {/* 미리보기 */}
           {imageUrl ? (
             <img
               src={imageUrl}
@@ -156,87 +149,83 @@ const [uploading, setUploading] = useState(false);
             </div>
           )}
 
-          {/* 업로드 버튼 */}
           <div className="flex flex-col gap-2">
-<label
-  className={`cursor-pointer px-6 py-2 rounded-xl border border-gray-200 text-gray-700 bg-white hover:bg-gray-50 transition-all ${
-    uploading ? 'opacity-50 pointer-events-none' : ''
-  }`}
->
-  {uploading ? '업로드 중...' : '이미지 선택'}
-  <input
-    type="file"
-    accept="image/*"
-    className="hidden"
-    onChange={async (e) => {
-      if (!e.target.files?.length) return;
-      const file = e.target.files[0];
-      setImageFile(file);
-      setUploading(true);
+          <label
+            className={`cursor-pointer px-6 py-2 rounded-xl border border-gray-200 text-gray-700 bg-white hover:bg-gray-50 transition-all ${
+              uploading ? 'opacity-50 pointer-events-none' : ''
+            }`}
+          >
+          {uploading ? '업로드 중...' : '이미지 선택'}
+          <input
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={async (e) => {
+              if (!e.target.files?.length) return;
+              const file = e.target.files[0];
+              setImageFile(file);
+              setUploading(true);
 
-      try {
-        const res = await uploadMenuImage(storeId, file);
-        if (res.isSuccess) {
-          setImageKey(res.result.imageKey);
-          setImageUrl(res.result.imageUrl);
-        } else {
-          alert("이미지 업로드 실패: " + res.message);
-          setImageFile(null);
-        }
-      } catch (err) {
-        console.error(err);
-        alert("이미지 업로드 중 오류가 발생했습니다.");
-        setImageFile(null);
-      } finally {
-        setUploading(false);
-      }
-    }}
-  />
-</label>
+              try {
+                const res = await uploadMenuImage(storeId, file);
+                if (res.isSuccess) {
+                  setImageKey(res.result.imageKey);
+                  setImageUrl(res.result.imageUrl);
+                } else {
+                  alert("이미지 업로드 실패: " + res.message);
+                  setImageFile(null);
+                }
+              } catch (err) {
+                console.error(err);
+                alert("이미지 업로드 중 오류가 발생했습니다.");
+                setImageFile(null);
+              } finally {
+                setUploading(false);
+              }
+            }}
+          />
+        </label>
 
-{/* 이미지 삭제 버튼 */}
-{imageUrl && (
-  <button
-    type="button"
-    className="ml-2 px-4 py-2 bg-red-100 text-red-600 rounded-xl"
-    onClick={async () => {
-      // 등록 전 이미지 삭제 (서버 요청 없음)
-      if (!editingMenu?.menuId) {
-        setImageFile(null);
-        setImageUrl(null);
-        setImageKey("");
-        return;
-      }
+        {imageUrl && (
+          <button
+            type="button"
+            className="ml-2 px-4 py-2 bg-red-100 text-red-600 rounded-xl"
+            onClick={async () => {
+              if (!editingMenu?.menuId) {
+                setImageFile(null);
+                setImageUrl(null);
+                setImageKey("");
+                return;
+              }
 
-      
-      // 수정 모드, 서버에 삭제 요청
-      const menuId = editingMenu.id ; // 타입 확실히 지정
-      if (!menuId) {
-        alert("메뉴 ID가 존재하지 않아 삭제할 수 없습니다.");
-        return;
-      }
+              
+              const menuId = editingMenu.id ; 
+              if (!menuId) {
+                alert("메뉴 ID가 존재하지 않아 삭제할 수 없습니다.");
+                return;
+              }
 
-      try {
-        const res = await deleteMenuImage(storeId, menuId);
-        if (res.isSuccess) {
-          setImageUrl(null);
-          setImageKey(null);
-          alert("이미지가 삭제되었습니다.");
-          if (onImageDelete) onImageDelete(); // 부모에게 알림
-        } else {
-          alert("이미지 삭제 실패: " + res.message);
-        }
-      } catch (err) {
-        console.error(err);
-        alert("이미지 삭제 중 오류가 발생했습니다.");
-      }
-    }}
-  >
-    삭제
-  </button>
-)}
-          </div>
-</div>
+              try {
+                const res = await deleteMenuImage(storeId, menuId);
+                if (res.isSuccess) {
+                  setImageUrl(null);
+                  setImageKey(null);
+                  alert("이미지가 삭제되었습니다.");
+                  if (onImageDelete) onImageDelete(); // 부모에게 알림
+                } else {
+                  alert("이미지 삭제 실패: " + res.message);
+                }
+              } catch (err) {
+                console.error(err);
+                alert("이미지 삭제 중 오류가 발생했습니다.");
+              }
+            }}
+          >
+            삭제
+          </button>
+        )}
+        </div>
+      </div>
 
 
 

--- a/src/components/owner/menuFormModal.tsx
+++ b/src/components/owner/menuFormModal.tsx
@@ -49,7 +49,11 @@ const [uploading, setUploading] = useState(false);
 
     } else {
       setFormData({ name: '', category: 'MAIN', price: '', description: '' });
+      setImageUrl(null);
+      setImageKey(null);
     }
+    setImageFile(null);
+    setUploading(false);
   }, [editingMenu, isOpen]);
 
   if (!isOpen) return null;
@@ -191,15 +195,15 @@ const [uploading, setUploading] = useState(false);
             type="button"
             className="cursor-pointer ml-2 px-4 py-2 bg-red-100 text-red-600 rounded-xl"
             onClick={async () => {
-              if (!editingMenu?.menuId) {
+              if (!editingMenu?.id) {
                 setImageFile(null);
                 setImageUrl(null);
-                setImageKey("");
+                setImageKey(null);
                 return;
               }
 
               
-              const menuId = editingMenu.id ; 
+              const menuId = editingMenu.id; 
               if (!menuId) {
                 alert("메뉴 ID가 존재하지 않아 삭제할 수 없습니다.");
                 return;

--- a/src/components/owner/menuManagement.tsx
+++ b/src/components/owner/menuManagement.tsx
@@ -169,8 +169,8 @@ const MenuManagement: React.FC<MenuManagementProps> = ({ storeId }) => {
         const menuIdNum = Number(id);
         const res = await deleteMenus(storeId, [menuIdNum]);
 
-        if (res.success) {
-          setMenus(prev => prev.filter(m => !res.data.deletedMenuIds.includes(Number(m.id))));
+        if (res.isSuccess) {
+          setMenus(prev => prev.filter(m => Number(m.id) !== menuIdNum));
           alert(res.message || '메뉴가 삭제되었습니다.');
         } else {
           alert('메뉴 삭제 실패: ' + res.message);

--- a/src/components/owner/menuManagement.tsx
+++ b/src/components/owner/menuManagement.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { Plus, Pencil, Trash2, Check, X } from 'lucide-react';
+import { Plus, Pencil, Trash2 } from 'lucide-react';
 import { mockMenusByRestaurantId } from '../../mock/menus';
 import MenuFormModal from './menuFormModal';
-import type { MenuCategory } from '@/types/menus';
 import { deleteMenus } from '@/api/owner/menus';
-import { deleteMenuImage, getMenus, updateMenuSoldOut } from '@/api/owner/menus';
+import { getMenus, updateMenuSoldOut } from '@/api/owner/menus';
 
 
 interface MenuManagementProps {
@@ -17,44 +16,38 @@ interface Category {
 }
 
 interface LocalMenu {
-  id: string; // local id (string)
+  id: string;
   name: string;
   description?: string;
   price: number;
   category?: string;
   imageUrl?: string | null;
   isSoldOut?: boolean;
-  isActive?: boolean; // 로컬에서 관리
+  isActive?: boolean;
 }
 
 type CategoryType = string;
 
-const MenuManagement: React.FC<MenuManagementProps> = ({storeId}) => {
-
+const MenuManagement: React.FC<MenuManagementProps> = ({ storeId }) => {
   const restaurantId = storeId;
 
-  const STORAGE_KEY_CAT = restaurantId ? `menu-categories-${restaurantId}` : 'menu-categories-temp';
-  const STORAGE_KEY_MENU = restaurantId ? `menu-items-${restaurantId}` : 'menu-items-temp';
-
+  // API에서 고정으로 제공하는 카테고리만 허용합니다. (ALL은 전체 보기용)
   const DEFAULT_CATEGORIES: Category[] = [
     { id: 'ALL', label: '전체' },
     { id: 'MAIN', label: '메인 메뉴' },
     { id: 'SIDE', label: '사이드 메뉴' },
-    { id: 'DRINK', label: '음료' },
+    { id: 'BEVERAGE', label: '음료' },
+    { id: 'ALCOHOL', label: '주류' },
   ];
 
-
   const [menus, setMenus] = useState<any[]>([]);
-  const [categories, setCategories] = useState<Category[]>(DEFAULT_CATEGORIES);
+  // 카테고리는 고정이므로 별도의 수정/저장 로직이 없습니다.
+  const [categories] = useState<Category[]>(DEFAULT_CATEGORIES);
   const [activeCategory, setActiveCategory] = useState<CategoryType>('ALL');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [draggedIdx, setDraggedIdx] = useState<number | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingMenu, setEditingMenu] = useState<any>(null);
-  const [editingCatId, setEditingCatId] = useState<string | null>(null);
-  const [tempCatLabel, setTempCatLabel] = useState('');
-  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
 
   const mapServerToLocal = (s: any): LocalMenu => ({
     id: String(s.menuId ?? `MENU_${Date.now()}`),
@@ -64,25 +57,12 @@ const MenuManagement: React.FC<MenuManagementProps> = ({storeId}) => {
     category: s.category ?? undefined,
     imageUrl: s.imageUrl ?? null,
     isSoldOut: !!s.isSoldOut,
-    isActive: true, // 서버에서 제공하지 않으면 기본 활성화 상태를 true로 둡니다.
+    isActive: true,
   });
 
-
-
-
   useEffect(() => {
-    const savedCats = localStorage.getItem(STORAGE_KEY_CAT);
-    if (savedCats) {
-      try {
-        setCategories(JSON.parse(savedCats));
-      } catch {
-        setCategories(DEFAULT_CATEGORIES);
-      }
-    } else {
-      setCategories(DEFAULT_CATEGORIES);
-    }
+    const STORAGE_KEY_MENU = restaurantId ? `menu-items-${restaurantId}` : 'menu-items-temp';
 
-    // 2) 메뉴 불러오기: 우선 로컬스토리지 -> 서버 호출 -> 실패시 mock fallback
     const savedMenus = localStorage.getItem(STORAGE_KEY_MENU);
     if (savedMenus) {
       try {
@@ -92,8 +72,7 @@ const MenuManagement: React.FC<MenuManagementProps> = ({storeId}) => {
       }
     }
 
-  if (!restaurantId) {
-      // storeId 없으면 mock 보여주기 (개발용)
+    if (!restaurantId) {
       const initialMenus = mockMenusByRestaurantId[restaurantId ?? ''] || [];
       if (!savedMenus) {
         const local = initialMenus.map(mapServerToLocal);
@@ -103,29 +82,26 @@ const MenuManagement: React.FC<MenuManagementProps> = ({storeId}) => {
       return;
     }
 
-    // 실제 서버에서 메뉴를 가져옴
     (async () => {
       setIsLoading(true);
       setError(null);
       try {
-      const res = await getMenus(restaurantId);
-      if (res.isSuccess && res.result && Array.isArray(res.result.menus)) {
-        const serverMenus = res.result.menus.map(mapServerToLocal);
+        const res = await getMenus(restaurantId);
+        if (res.isSuccess && res.result && Array.isArray(res.result.menus)) {
+          const serverMenus = res.result.menus.map(mapServerToLocal);
 
-        // 로컬에서 임시로 추가한 메뉴만 추출
-        const localTempMenus = menus.filter(m => m.id.startsWith('MENU_'));
+          const localTempMenus = menus.filter(m => m.id.startsWith('MENU_'));
 
-        // 서버 메뉴 + 로컬 임시 메뉴 병합
-        const mergedMenus = [...serverMenus, ...localTempMenus];
+          const mergedMenus = [...serverMenus, ...localTempMenus];
 
-        setMenus(mergedMenus);
-        localStorage.setItem(STORAGE_KEY_MENU, JSON.stringify(mergedMenus));
-      } else {
-        setError(res.message || '메뉴를 가져오는 중 문제가 발생했습니다.');
-      }
-    } catch (err: any) {
-      console.error('getMenus error', err);
-      setError('메뉴를 불러오는 데 실패했습니다. 네트워크를 확인해주세요.');
+          setMenus(mergedMenus);
+          localStorage.setItem(STORAGE_KEY_MENU, JSON.stringify(mergedMenus));
+        } else {
+          setError(res.message || '메뉴를 가져오는 중 문제가 발생했습니다.');
+        }
+      } catch (err: any) {
+        console.error('getMenus error', err);
+        setError('메뉴를 불러오는 데 실패했습니다. 네트워크를 확인해주세요.');
 
         const initialMenus = mockMenusByRestaurantId[restaurantId] || [];
         if (initialMenus.length > 0) {
@@ -137,166 +113,100 @@ const MenuManagement: React.FC<MenuManagementProps> = ({storeId}) => {
         setIsLoading(false);
       }
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [restaurantId]);
 
   useEffect(() => {
-    if (categories.length > 0 && restaurantId) {
-      localStorage.setItem(STORAGE_KEY_CAT, JSON.stringify(categories));
-    }
-  }, [categories, restaurantId]);
-
-  useEffect(() => {
     if (restaurantId) {
+      const STORAGE_KEY_MENU = `menu-items-${restaurantId}`;
       localStorage.setItem(STORAGE_KEY_MENU, JSON.stringify(menus));
     }
   }, [menus, restaurantId]);
 
-
-  const handleDragStart = (idx: number) => {
-    if (categories[idx].id === 'ALL') return;
-    setDraggedIdx(idx);
-  };
-
-const handleDragOver = (e: React.DragEvent) => {
-  e.preventDefault()
-};
-
-const handleDrop = (targetIdx: number) => {
-  if (draggedIdx === null || draggedIdx === targetIdx) return;
-
-  const newCategories = [...categories];
-  const draggedItem = newCategories[draggedIdx];
-
-  newCategories.splice(draggedIdx, 1);
-  newCategories.splice(targetIdx, 0, draggedItem);
-
-  setCategories(newCategories);
-  setDraggedIdx(null);
-};
-
   const toggleActive = (id: string) => {
-    setMenus(prev => prev.map(menu => 
+    setMenus(prev => prev.map(menu =>
       menu.id === id ? { ...menu, isActive: !menu.isActive } : menu
     ));
   };
 
-const handleFormSubmit = (menuData: any) => {
-  setMenus(prev => {
-    // id 비교는 문자열로 통일
-    const incomingId = menuData.id ? String(menuData.id) : null;
+  const handleFormSubmit = (menuData: any) => {
+    setMenus(prev => {
+      const incomingId = menuData.id ? String(menuData.id) : null;
 
-const existingIndex = prev.findIndex(m => String(m.id) === incomingId);
-    if (existingIndex !== -1) {
-      const updatedMenus = [...prev];
-      updatedMenus[existingIndex] = {
-        ...prev[existingIndex], // 기존 상태(isActive 등) 보존
-        ...menuData,            // 수정된 내용 덮어쓰기
-        price: Number(menuData.price)
-      };
-      return updatedMenus;
-    } else {
-      return [{ ...menuData, price: Number(menuData.price) }, ...prev];
-    }
-  });
+      const existingIndex = prev.findIndex(m => String(m.id) === incomingId);
+      if (existingIndex !== -1) {
+        const updatedMenus = [...prev];
+        updatedMenus[existingIndex] = {
+          ...prev[existingIndex],
+          ...menuData,
+          price: Number(menuData.price)
+        };
+        return updatedMenus;
+      } else {
+        return [{ ...menuData, price: Number(menuData.price) }, ...prev];
+      }
+    });
 
-  // 모달 닫고 편집 상태 클리어
-  setIsModalOpen(false);
-  setEditingMenu(null);
-};
-
-const handleEditClick = (menu: any) => {
-  setEditingMenu(menu);
-  setIsModalOpen(true);
-};
-
-const handleAddClick = () => {
-  setEditingMenu(null);
-  setIsModalOpen(true);
-};
-
-  const handleAddCategory = () => {
-    const newId = `CAT_${Date.now()}`;
-    const newCat = { id: newId, label: '새 카테고리' };
-    setCategories([...categories, newCat]);
-    setEditingCatId(newId);
-    setTempCatLabel('새 카테고리');
+    setIsModalOpen(false);
+    setEditingMenu(null);
   };
 
-  const startEditCategory = (id: string, label: string) => {
-    setEditingCatId(id);
-    setTempCatLabel(label);
+  const handleEditClick = (menu: any) => {
+    setEditingMenu(menu);
+    setIsModalOpen(true);
   };
 
-  const saveCategory = (id: string) => {
-    if (!tempCatLabel.trim()) return;
-    setCategories(prev => prev.map(c => c.id === id ? { ...c, label: tempCatLabel } : c));
-    setEditingCatId(null);
+  const handleAddClick = () => {
+    setEditingMenu(null);
+    setIsModalOpen(true);
   };
-
-  const deleteCategory = (id: string) => {
-    const fallback = categories.find(c => c.id !== id && c.id !== 'ALL')?.id;
-    if (window.confirm('카테고리를 삭제하시겠습니까?')) {
-      if (!fallback) return alert('최소 하나의 카테고리는 필요합니다.');
-      setMenus(prev => prev.map(m => m.category === id ? { ...m, category: fallback } : m));
-      setCategories(prev => prev.filter(c => c.id !== id));
-      if (activeCategory === id) setActiveCategory('ALL');
-    }
-  }
 
   const deleteMenu = async (id: string) => {
-  if (!storeId) return alert("storeId가 없습니다.");
+    if (!storeId) return alert("storeId가 없습니다.");
 
-  if (window.confirm('정말로 이 메뉴를 삭제하시겠습니까?')) {
-    try {
-      // 서버 API 호출
-      const menuIdNum = Number(id); // API는 number 배열
-      const res = await deleteMenus(storeId, [menuIdNum]);
+    if (window.confirm('정말로 이 메뉴를 삭제하시겠습니까?')) {
+      try {
+        const menuIdNum = Number(id);
+        const res = await deleteMenus(storeId, [menuIdNum]);
 
-      if (res.success) {
-        // 로컬 상태에서 삭제
-        setMenus(prev => prev.filter(m => !res.data.deletedMenuIds.includes(Number(m.id))));
-        alert(res.message || '메뉴가 삭제되었습니다.');
-      } else {
-        alert('메뉴 삭제 실패: ' + res.message);
+        if (res.success) {
+          setMenus(prev => prev.filter(m => !res.data.deletedMenuIds.includes(Number(m.id))));
+          alert(res.message || '메뉴가 삭제되었습니다.');
+        } else {
+          alert('메뉴 삭제 실패: ' + res.message);
+        }
+      } catch (err) {
+        console.error(err);
+        alert('메뉴 삭제 중 오류가 발생했습니다.');
       }
-    } catch (err) {
-      console.error(err);
-      alert('메뉴 삭제 중 오류가 발생했습니다.');
     }
-  }
-};
+  };
 
-const toggleSoldOutOnServer = async (id: string, targetSoldOut: boolean) => {
-  if (!storeId) return alert("storeId가 없습니다.");
+  const toggleSoldOutOnServer = async (id: string, targetSoldOut: boolean) => {
+    if (!storeId) return alert("storeId가 없습니다.");
 
-  const menuIdNum = Number(id);
-  if (Number.isNaN(menuIdNum)) return alert("메뉴 ID가 유효하지 않습니다.");
+    const menuIdNum = Number(id);
+    if (Number.isNaN(menuIdNum)) return alert("메뉴 ID가 유효하지 않습니다.");
 
-  try {
-    // 서버 호출 전 로컬에서 즉시 UI 반영(옵셔널). 안정성을 위해 서버 응답으로 확정하도록 아래는 서버 응답 기준 업데이트.
-    const res = await updateMenuSoldOut(storeId, menuIdNum, targetSoldOut);
+    try {
+      const res = await updateMenuSoldOut(storeId, menuIdNum, targetSoldOut);
 
-    if (res.isSuccess) {
-      // API 스펙이 res.data 또는 res.result 형태일 수 있으니 존재하는 필드로 처리
-      const newSoldOut = (res.result && (res.result as any).isSoldOut !== undefined);
+      if (res.isSuccess) {
+        const newSoldOut = (res.result && (res.result as any).isSoldOut !== undefined);
 
-
-      setMenus(prev => prev.map(m => String(m.id) === String(id) ? { ...m, isSoldOut: !!newSoldOut } : m));
-      alert(res.message || (newSoldOut ? '품절 처리되었습니다.' : '품절 해제되었습니다.'));
-    } else {
-      alert('품절 상태 변경 실패: ' + res.message);
+        setMenus(prev => prev.map(m => String(m.id) === String(id) ? { ...m, isSoldOut: !!newSoldOut } : m));
+        alert(res.message || (newSoldOut ? '품절 처리되었습니다.' : '품절 해제되었습니다.'));
+      } else {
+        alert('품절 상태 변경 실패: ' + res.message);
+      }
+    } catch (err: any) {
+      console.error('updateMenuSoldOut error', err);
+      alert('품절 상태 변경 중 오류가 발생했습니다.');
     }
-  } catch (err: any) {
-    console.error('updateMenuSoldOut error', err);
-    alert('품절 상태 변경 중 오류가 발생했습니다.');
-  }
-};
+  };
 
-
-
-
-  const filteredMenus = activeCategory === 'ALL' 
-    ? menus 
+  const filteredMenus = activeCategory === 'ALL'
+    ? menus
     : menus.filter(menu => menu.category === activeCategory);
 
   if (isLoading) return <div className="px-8 py-10 text-gray-500 font-medium">데이터를 불러오는 중...</div>;
@@ -304,27 +214,27 @@ const toggleSoldOutOnServer = async (id: string, targetSoldOut: boolean) => {
 
   return (
     <div className="max-w-7xl mx-auto px-8 py-10">
-      {/* 헤더 섹션 */}
+
       <div className="flex justify-between items-start mb-10">
         <div>
           <h2 className="text-2xl text-gray-900 mb-1">메뉴 관리</h2>
           <p className="text-gray-500 text-sm font-medium">총 {menus.length}개의 메뉴가 등록되어 있습니다</p>
         </div>
         <button className="cursor-pointer bg-blue-600 text-white px-5 py-2.5 rounded-xl flex items-center gap-2 text-sm font-bold shadow-lg shadow-blue-100 hover:bg-blue-700 transition-all"
-        onClick={handleAddClick}>
+          onClick={handleAddClick}>
           <Plus size={18} /> 메뉴 추가
         </button>
       </div>
 
-      {/* 카테고리 탭 */}
+
       <div className="overflow-x-auto flex gap-3 mb-8 p-4 rounded-lg bg-white">
         {categories.map(cat => (
           <button
             key={cat.id}
             onClick={() => setActiveCategory(cat.id)}
             className={`cursor-pointer px-5 py-2.5 rounded-lg text-md transition-all ${
-              activeCategory === cat.id 
-                ? 'bg-blue-600 text-white' 
+              activeCategory === cat.id
+                ? 'bg-blue-600 text-white'
                 : 'bg-gray-100 border border-gray-100 text-gray-500 hover:bg-gray-200'
             }`}
           >
@@ -333,7 +243,7 @@ const toggleSoldOutOnServer = async (id: string, targetSoldOut: boolean) => {
         ))}
       </div>
 
-      {/* 메뉴 카드 그리드 */}
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
         {filteredMenus.map(menu => (
           <div
@@ -346,14 +256,14 @@ const toggleSoldOutOnServer = async (id: string, targetSoldOut: boolean) => {
             `}
           >
             {menu.imageUrl && (
-              <img 
-                src={menu.imageUrl} 
-                alt={menu.name} 
+              <img
+                src={menu.imageUrl}
+                alt={menu.name}
                 className="w-full h-40 object-cover rounded-lg mb-4"
               />
             )}
 
-            
+
             <div className="flex justify-between items-start mb-4">
               <div>
                 <div className="flex items-center gap-2 mb-1">
@@ -389,9 +299,8 @@ const toggleSoldOutOnServer = async (id: string, targetSoldOut: boolean) => {
 
             <div className="flex justify-between items-center mt-auto">
               <span className="text-lg text-gray-900">{menu.price.toLocaleString()}원</span>
-              
-              {/* 활성 토글 스위치 */}
-              <button 
+
+              <button
                 onClick={() => toggleSoldOutOnServer(menu.id, !menu.isSoldOut)}
                 role="switch"
                 aria-checked={!menu.isSoldOut}
@@ -405,112 +314,23 @@ const toggleSoldOutOnServer = async (id: string, targetSoldOut: boolean) => {
         ))}
       </div>
 
-      {/* 카테고리 관리 섹션*/}
-      <section className="bg-white border border-gray-100 rounded-lg p-8 shadow-sm">
-  <div className="flex justify-between items-center mb-6">
-    <h3 className="text-lg text-gray-700 font-semibold uppercase tracking-widest">카테고리 관리</h3>
-    <p className="text-xs text-gray-400">드래그하여 순서를 변경할 수 있습니다</p>
-  </div>
-  
-  <div className="space-y-2">
-    {categories.filter(c => c.id !== 'ALL').map((cat) => {
-      // 'ALL'을 제외했으므로 실제 원본 배열에서의 인덱스를 구함
-      const realIdx = categories.findIndex(c => c.id === cat.id);
-      
-      return (
-        <div 
-          key={cat.id} 
-          draggable // 드래그 가능하게 설정
-          onDragStart={() => handleDragStart(realIdx)}
-          onDragOver={(e) => {
-            e.preventDefault();
-            setHoverIdx(realIdx);
-          }}
-          onDrop={() => {
-            handleDrop(realIdx);
-            setHoverIdx(null);
-          }}
-          className={`flex items-center justify-between p-4 border-2 border-transparent hover:border-blue-100 hover:bg-blue-50/50 rounded-2xl transition-all group cursor-move ${
-            draggedIdx === realIdx ? 'opacity-40 bg-gray-100 border-blue-400 bg-blue-50' : 'bg-white'
-          }`}
-        >
-          <div className="flex items-center gap-4 flex-1">
-            {/* 드래그 핸들 아이콘 (점 6개) */}
-            <div className="flex flex-col gap-0.5 opacity-30 group-hover:opacity-100 transition-opacity">
-              <div className="flex gap-0.5">
-                <div className="w-1 h-1 bg-gray-400 rounded-full" />
-                <div className="w-1 h-1 bg-gray-400 rounded-full" />
-              </div>
-              <div className="flex gap-0.5">
-                <div className="w-1 h-1 bg-gray-400 rounded-full" />
-                <div className="w-1 h-1 bg-gray-400 rounded-full" />
-              </div>
-              <div className="flex gap-0.5">
-                <div className="w-1 h-1 bg-gray-400 rounded-full" />
-                <div className="w-1 h-1 bg-gray-400 rounded-full" />
-              </div>
-            </div>
+      {/* 카테고리 추가/수정 UI 제거: 서버(또는 API)에서 제공하는 고정 카테고리만 허용합니다. */}
 
-            {editingCatId === cat.id ? (
-              <div className="flex items-center gap-2 flex-1" onClick={(e) => e.stopPropagation()}>
-                <input 
-                  autoFocus
-                  className="border-b-2 border-blue-500 outline-none bg-transparent px-1 py-1 text-gray-700 w-full max-w-[200px]"
-                  value={tempCatLabel}
-                  onChange={(e) => setTempCatLabel(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && saveCategory(cat.id)}
-                />
-                <button onClick={() => saveCategory(cat.id)} className="p-1 text-blue-600"><Check size={18}/></button>
-                <button onClick={() => setEditingCatId(null)} className="p-1 text-gray-400"><X size={18}/></button>
-              </div>
-            ) : (
-              <span className="text-gray-700">{cat.label}</span>
-            )}
-          </div>
-
-          {!editingCatId && (
-            <div className="flex gap-4 text-sm opacity-0 group-hover:opacity-100 transition-opacity">
-              <button 
-                onClick={(e) => { e.stopPropagation(); startEditCategory(cat.id, cat.label); }}
-                className="text-blue-600 hover:text-blue-700"
-              >
-                수정
-              </button>
-              <button 
-                onClick={(e) => { e.stopPropagation(); deleteCategory(cat.id); }}
-                className="text-red-500 hover:text-red-600"
-              >
-                삭제
-              </button>
-            </div>
-          )}
-        </div>
-      );
-    })}
-  </div>
-        <button 
-          onClick={handleAddCategory}
-          className="cursor-pointer w-full mt-4 py-4 border-2 border-dashed border-gray-100 rounded-2xl text-gray-700 text-sm font-bold hover:bg-gray-50 hover:border-blue-200 transition-all flex items-center justify-center gap-2"
-        >
-          <Plus size={16} /> 카테고리 추가
-        </button>
-      </section>
-
-      <MenuFormModal 
-        isOpen={isModalOpen} 
-        onClose={() => setIsModalOpen(false)} 
+      <MenuFormModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
         onSubmit={handleFormSubmit}
         categories={categories}
         editingMenu={editingMenu}
         storeId={storeId!}
         onImageDelete={() => {
           if (!editingMenu) return;
-            setMenus((prev) =>
-              prev.map((m) =>
-                m.id === editingMenu.id ? { ...m, imageUrl: null, imageKey: null } : m
-              )
-            );
-          }}
+          setMenus((prev) =>
+            prev.map((m) =>
+              m.id === editingMenu.id ? { ...m, imageUrl: null, imageKey: null } : m
+            )
+          );
+        }}
       />
     </div>
   );

--- a/src/components/owner/menuManagement.tsx
+++ b/src/components/owner/menuManagement.tsx
@@ -157,12 +157,23 @@ const MenuManagement: React.FC<MenuManagementProps> = ({ storeId }) => {
   };
 
   const handleAddClick = () => {
+      if (!storeId) {
+    alert("가게 정보가 없습니다.");
+    return;
+  }
     setEditingMenu(null);
     setIsModalOpen(true);
   };
 
   const deleteMenu = async (id: string) => {
     if (!storeId) return alert("storeId가 없습니다.");
+
+    if (id.startsWith('MENU_')) {
+      if (window.confirm('정말로 이 메뉴를 삭제하시겠습니까?')) {
+        setMenus(prev => prev.filter(m => m.id !== id));
+      }
+      return;
+    }
 
     if (window.confirm('정말로 이 메뉴를 삭제하시겠습니까?')) {
       try {
@@ -192,9 +203,9 @@ const MenuManagement: React.FC<MenuManagementProps> = ({ storeId }) => {
       const res = await updateMenuSoldOut(storeId, menuIdNum, targetSoldOut);
 
       if (res.isSuccess) {
-        const newSoldOut = (res.result && (res.result as any).isSoldOut !== undefined);
+        const newSoldOut = res.result?.isSoldOut ?? targetSoldOut;
 
-        setMenus(prev => prev.map(m => String(m.id) === String(id) ? { ...m, isSoldOut: !!newSoldOut } : m));
+        setMenus(prev => prev.map(m => String(m.id) === String(id) ? { ...m, isSoldOut: newSoldOut } : m));
         alert(res.message || (newSoldOut ? '품절 처리되었습니다.' : '품절 해제되었습니다.'));
       } else {
         alert('품절 상태 변경 실패: ' + res.message);

--- a/src/components/owner/tableDetailModal.tsx
+++ b/src/components/owner/tableDetailModal.tsx
@@ -126,7 +126,6 @@ const tableType = getTableType(tableInfo.maxCapacity);
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[100] p-4" onClick={onClose}>
       <div className="bg-white w-full max-w-2xl rounded-lg shadow-2xl overflow-hidden flex flex-col max-h-[90vh] animate-in zoom-in-95 duration-200" onClick={(e) => e.stopPropagation()}>
         
-        {/* 헤더 */}
         <div className="flex justify-between items-center px-6 py-5 border-b border-gray-100 flex-shrink-0">
           <div className="flex items-center gap-3">
             {step !== 'DETAIL' && (
@@ -144,7 +143,6 @@ const tableType = getTableType(tableInfo.maxCapacity);
         </div>
 
         <div className="p-6 overflow-y-auto flex-1 custom-scrollbar">
-          {/* [Step 1] 상세 정보 */}
           {step === 'DETAIL' && (
             <div className="space-y-6 animate-in fade-in duration-300">
               <div className="w-full h-70 rounded-lg border border-gray-100 overflow-hidden">
@@ -219,7 +217,6 @@ const tableType = getTableType(tableInfo.maxCapacity);
             </div>
           )}
 
-          {/* [Step 2] 달력 */}
           {step === 'CALENDAR' && (
             <div className="animate-in slide-in-from-right-5 duration-300 space-y-5">
               <div className="px-1 space-y-1">
@@ -244,7 +241,6 @@ const tableType = getTableType(tableInfo.maxCapacity);
                   const weekDay = dateObj.getDay(); 
                   const weekDayKorean = ['일','월','화','수','목','금','토'][weekDay];
 
-                  // 휴무일 체크
                   const isClosedDay = closedDays.includes(weekDayKorean);
                   
                   return (
@@ -278,7 +274,6 @@ const tableType = getTableType(tableInfo.maxCapacity);
             </div>
           )}
 
-          {/* [Step 3] 시간 설정 */}
           {step === 'SLOTS' && (
             <div className="animate-in slide-in-from-right-5 duration-300 space-y-4">
               <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg flex justify-between items-center text-blue-900">

--- a/src/types/menus.ts
+++ b/src/types/menus.ts
@@ -7,6 +7,7 @@ export type MenuItem = {
   category: MenuCategory;
   description?: string;
   imageUrl?: string;
+  imageKey?: string;
   price: number;
   isSoldOut: boolean;
   isActive: boolean;


### PR DESCRIPTION
## 💡 개요

내가게관리 메뉴관리 API 연동

## 🔢 관련 이슈 링크
- Closes #60 

## 💻 작업내용
- 메뉴 조회
- 메뉴 등록
- 메뉴 삭제
- 메뉴 이미지 선업로드
- 메뉴 수정
- 품절 여부 변경
- 등록된 메뉴 이미지 삭제


## 📌 변경사항PR
- [x] FEAT: 새로운 기능 추가
- [ ] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [ ] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
- 적용 안된 것처럼 보일 때 새로고침 한 번씩 해주세요!

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 메뉴의 생성·수정·삭제 및 이미지 업로드/삭제 지원
  * 메뉴에 이미지 미리보기와 이미지 관리(업로드/삭제) UI 추가
  * 메뉴별 품절 상태 토글(서버 동기화) 추가
  * 메뉴 추가/편집 시 서버와 로컬(브라우저) 동기화 및 저장

* **수정/정리**
  * 코드 주석/포맷 소소한 정리 및 타입에 이미지 키(imageKey) 필드 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->