### PR TITLE
feat: 1:1 문의 등록 API 연동 

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -61,6 +61,11 @@ api.interceptors.response.use(
     }
 
     if (apiError.status === 401 && originalRequest) {
+      const isGuest = !useAuthStore.getState().accessToken;
+      // 비회원이면 재발급x
+      if (isGuest) {
+        return Promise.reject(apiError);
+      }
       // 이미 재시도한 요청이거나, 재발급 요청 자체가 실패인 경우 -> 로그아웃
       if (
         originalRequest._retry ||

--- a/src/api/inquiry.ts
+++ b/src/api/inquiry.ts
@@ -1,0 +1,16 @@
+import type {
+  ResponseInquiryDTO,
+  SupportFormValues,
+} from "@/components/customer-support/support.schema";
+import type { ApiResponse } from "@/types/api";
+import { api } from "./axios";
+
+export const postInquiry = async (
+  body: SupportFormValues,
+): Promise<ResponseInquiryDTO> => {
+  const { data } = await api.post<ApiResponse<ResponseInquiryDTO>>(
+    "/api/v1/inquiries",
+    body,
+  );
+  return data.result;
+};

--- a/src/components/customer-support/SupportModal.tsx
+++ b/src/components/customer-support/SupportModal.tsx
@@ -11,6 +11,10 @@ import { supportSchema, type SupportFormValues } from "./support.schema";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { Label } from "@/components/ui/label";
+import { useMutation } from "@tanstack/react-query";
+import { postInquiry } from "@/api/inquiry";
+import { getErrorMessage } from "@/utils/error";
+
 
 interface SupportModalProps {
   isOpen: boolean;
@@ -47,11 +51,23 @@ export default function SupportModal({
     register,
     handleSubmit,
     reset,
-    formState: { errors, isSubmitting },
+    formState: { errors },
   } = useForm<SupportFormValues>({
     resolver: zodResolver(supportSchema),
     defaultValues,
     mode: "onSubmit",
+  });
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: postInquiry,
+    onSuccess: (data) => {
+      console.log("문의 접수 ID:", data.id);
+      onComplete();
+    },
+    onError: (error) => {
+      console.error(error);
+      alert(getErrorMessage(error));
+    },
   });
 
   // 폼 열릴 때마다 초기화
@@ -62,13 +78,7 @@ export default function SupportModal({
   }, [isOpen, reset]);
 
   const onSubmit = async (data: SupportFormValues) => {
-    try {
-      console.log("Support data:", data);
-      //await API
-      onComplete();
-    } catch (e) {
-      console.error("error:", e);
-    }
+    mutate(data);
   };
 
   return (
@@ -212,11 +222,11 @@ export default function SupportModal({
               </button>
               <button
                 type="submit"
-                disabled={isSubmitting}
+                disabled={isPending}
                 className="flex-1 px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors flex items-center justify-center gap-2 cursor-pointer"
               >
                 <Send className="size-4" />
-                {isSubmitting ? "문의 중..." : "문의하기"}
+                {isPending ? "문의 중..." : "문의하기"}
               </button>
             </div>
           </form>

--- a/src/components/customer-support/SupportModal.tsx
+++ b/src/components/customer-support/SupportModal.tsx
@@ -21,12 +21,21 @@ interface SupportModalProps {
 const inputStyle =
   "text-base bg-white w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none";
 
+const SUPPORT_TYPE_LABEL: Record<SupportFormValues["type"], string> = {
+  RESERVATION: "예약 문의",
+  PAYMENT_REFUND: "결제/환불 문의",
+  RESTAURANT_REGISTRATION: "식당 등록 문의",
+  REVIEW: "리뷰 관련",
+  TECH_SUPPORT: "기술 지원",
+  ETC: "기타",
+};
+
 const defaultValues: SupportFormValues = {
   name: "",
   email: "",
-  category: "예약",
-  subject: "",
-  message: "",
+  type: "RESERVATION",
+  title: "",
+  content: "",
 };
 
 export default function SupportModal({
@@ -98,6 +107,7 @@ export default function SupportModal({
                   id="name"
                   type="text"
                   placeholder="이름을 입력하세요"
+                  maxLength={20}
                   className={inputStyle}
                   {...register("name")}
                 />
@@ -115,6 +125,7 @@ export default function SupportModal({
                   id="email"
                   type="email"
                   placeholder="email@example.com"
+                  maxLength={50}
                   className={inputStyle}
                   {...register("email")}
                 />
@@ -126,59 +137,60 @@ export default function SupportModal({
 
             {/* 문의 유형 */}
             <div className="space-y-3">
-              <Label htmlFor="category" className="text-base font-medium">
+              <Label htmlFor="type" className="text-base font-medium">
                 문의 유형 <span className="text-red-500">*</span>
               </Label>
               <select
-                id="category"
+                id="type"
                 className={inputStyle + " cursor-pointer"}
-                {...register("category")}
+                {...register("type")}
               >
-                <option value="예약">예약 문의</option>
-                <option value="결제/환불">결제/환불 문의</option>
-                <option value="식당 등록">식당 등록 문의</option>
-                <option value="리뷰">리뷰 관련</option>
-                <option value="기술 지원">기술 지원</option>
-                <option value="기타">기타</option>
+                {Object.entries(SUPPORT_TYPE_LABEL).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
               </select>
-              {errors.category && (
+              {errors.type && (
                 <p className="text-sm text-red-500 mt-1 font-medium">
-                  {errors.category.message}
+                  {errors.type.message}
                 </p>
               )}
             </div>
 
             {/* 제목 */}
             <div className="space-y-3">
-              <Label htmlFor="subject" className="text-base font-medium">
+              <Label htmlFor="title" className="text-base font-medium">
                 제목 <span className="text-red-500">*</span>
               </Label>
               <input
-                id="subject"
+                id="title"
                 type="text"
                 placeholder="문의 제목을 입력하세요"
+                maxLength={100}
                 className={inputStyle}
-                {...register("subject")}
+                {...register("title")}
               />
-              {errors.subject && (
-                <p className="text-sm text-red-500">{errors.subject.message}</p>
+              {errors.title && (
+                <p className="text-sm text-red-500">{errors.title.message}</p>
               )}
             </div>
 
             {/* 문의 내용 */}
             <div className="space-y-3">
-              <Label htmlFor="message" className="text-base font-medium">
+              <Label htmlFor="content" className="text-base font-medium">
                 문의 내용 <span className="text-red-500">*</span>
               </Label>
               <textarea
-                id="message"
+                id="content"
                 rows={6}
                 placeholder="문의하실 내용을 자세히 입력하세요"
+                maxLength={2000}
                 className={inputStyle + " resize-none"}
-                {...register("message")}
+                {...register("content")}
               ></textarea>
-              {errors.message && (
-                <p className="text-sm text-red-500">{errors.message.message}</p>
+              {errors.content && (
+                <p className="text-sm text-red-500">{errors.content.message}</p>
               )}
             </div>
 

--- a/src/components/customer-support/support.schema.ts
+++ b/src/components/customer-support/support.schema.ts
@@ -1,25 +1,33 @@
 import z from "zod";
 
 export const supportSchema = z.object({
-  name: z.string().min(1, "이름을 입력하세요."),
+  name: z
+    .string()
+    .min(1, "이름을 입력하세요.")
+    .max(20, "20자 이내여야 합니다."),
 
   email: z
     .string()
     .min(1, { message: "이메일을 입력하세요." })
-    .email({ message: "올바른 이메일 형식이 아닙니다." }),
+    .email({ message: "올바른 이메일 형식이 아닙니다." })
+    .max(50, "50자 이내여야 합니다."),
 
-  category: z.enum([
-    "예약",
-    "결제/환불",
-    "식당 등록",
-    "리뷰",
-    "기술 지원",
-    "기타",
+  type: z.enum([
+    "RESERVATION",
+    "PAYMENT_REFUND",
+    "RESTAURANT_REGISTRATION",
+    "REVIEW",
+    "TECH_SUPPORT",
+    "ETC",
   ]),
-  subject: z.string().min(1, { message: "제목을 입력하세요." }),
-  message: z
+  title: z
     .string()
-    .min(1, { message: "문의하실 내용을 자세히 입력하세요." }),
+    .min(1, { message: "제목을 입력하세요." })
+    .max(100, "100자 이내여야 합니다."),
+  content: z
+    .string()
+    .min(1, { message: "문의하실 내용을 자세히 입력하세요." })
+    .max(2000, "2000자 이내여야 합니다."),
 });
 
 export type SupportFormValues = z.infer<typeof supportSchema>;

--- a/src/components/customer-support/support.schema.ts
+++ b/src/components/customer-support/support.schema.ts
@@ -31,3 +31,8 @@ export const supportSchema = z.object({
 });
 
 export type SupportFormValues = z.infer<typeof supportSchema>;
+
+export interface ResponseInquiryDTO {
+  id: number;
+  createdAt: string;
+}


### PR DESCRIPTION
## 💡 개요
1:1 문의 등록 API 연동 

## 🔢 관련 이슈 링크
- Closes #64

## 💻 작업내용
- 1:1 문의 등록 API 연동 
- src/api/axios.ts 인터셉터에 방어 로직 추가
401 에러 발생 시, 스토어에 토큰이 없는 상태(비회원)라면 재발급 로직을 실행하지 않고 즉시 에러를 반환하도록 수정

## 📌 변경사항PR
- [x] FEAT: 새로운 기능 추가
- [ ] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [x] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
-

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 문의 유형(예약, 결제/환불, 식당등록, 리뷰, 기술지원, 기타) 선택이 가능한 고객 지원 문의 기능을 추가했습니다.
  * 문의 제출 시 서버 전송과 응답 처리, 제출 완료 후 후속 흐름이 반영됩니다.

* **개선사항**
  * 입력값에 대한 실시간 검증 및 길이 제한(이름, 이메일, 제목, 내용)을 추가해 입력 오류를 즉시 안내합니다.
  * 전송 중 버튼 비활성화 및 상태 표시로 진행 상황을 개선했습니다.

* **버그 수정**
  * 비인증(게스트) 사용자에 대해 불필요한 토큰 갱신 시도를 차단하도록 처리해 불필요한 오류를 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->