### PR TITLE
feat: 접근 제어 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,30 +24,11 @@ import LoginErrorPage from "./pages/LoginErrorPage";
 import SuccessPage from "./pages/payment/SuccessPage";
 import FailPage from "./pages/payment/FailPage";
 import ReservationCompletePage from "./pages/ReservationCompletePage";
+import { PrivateRoute } from "./components/RouteGuards";
 
 const routes: RouteObject[] = [
   { path: "/oauth/callback", element: <OAuthCallbackPage /> },
   { path: "/login/error", element: <LoginErrorPage /> },
-  {
-    element: <PublicLayout />,
-    errorElement: <NotFound />,
-    children: [
-      { path: "/search", element: <SearchPage /> },
-      {
-        path: "/mypage",
-        element: <MyPageLayout />,
-        children: [
-          { index: true, element: <Navigate to="info" replace /> },
-          { path: "info", element: <MyInfoPage /> },
-          { path: "settings", element: <SettingsPage /> },
-          { path: "payment", element: <PaymentPage /> },
-          { path: "subscription", element: <SubscriptionPage /> },
-          { path: "reservations", element: <ReservationPage /> },
-          { path: "store", element: <StorePage /> },
-        ],
-      },
-    ],
-  },
   {
     path: "/",
     element: <Intro />,
@@ -59,31 +40,59 @@ const routes: RouteObject[] = [
     element: <CustomerSupportPage />,
     errorElement: <NotFound />,
   },
+
   {
-    path: "/mypage/store/register",
-    element: <StoreRegistrationPage />,
+    element: <PublicLayout />,
     errorElement: <NotFound />,
+    children: [
+      { path: "/search", element: <SearchPage /> },
+      {
+        element: <PrivateRoute />,
+        children: [
+          {
+            path: "/mypage",
+            element: <MyPageLayout />,
+            children: [
+              { index: true, element: <Navigate to="info" replace /> },
+              { path: "info", element: <MyInfoPage /> },
+              { path: "settings", element: <SettingsPage /> },
+              { path: "payment", element: <PaymentPage /> },
+              { path: "subscription", element: <SubscriptionPage /> },
+              { path: "reservations", element: <ReservationPage /> },
+              { path: "store", element: <StorePage /> },
+            ],
+          },
+        ],
+      },
+    ],
   },
   {
-    path: "/mypage/store/:storeId",
-    element: <OwnerPage />,
+    element: <PrivateRoute />,
     errorElement: <NotFound />,
+    children: [
+      {
+        path: "/mypage/store/register",
+        element: <StoreRegistrationPage />,
+      },
+      {
+        path: "/mypage/store/:storeId",
+        element: <OwnerPage />,
+      },
+      {
+        path: "/payment/success",
+        element: <SuccessPage />,
+      },
+      {
+        path: "/payment/fail",
+        element: <FailPage />,
+      },
+      {
+        path: "/reservation/complete",
+        element: <ReservationCompletePage />,
+      },
+    ],
   },
-  {
-    path: "/payment/success",
-    element: <SuccessPage />,
-    errorElement: <NotFound />,
-  },
-  {
-    path: "/payment/fail",
-    element: <FailPage />,
-    errorElement: <NotFound />,
-  },
-  {
-    path: "/reservation/complete",
-    element: <ReservationCompletePage />,
-    errorElement: <NotFound />,
-  },
+
   {
     path: "*",
     element: <NotFound />,

--- a/src/components/RouteGuards.tsx
+++ b/src/components/RouteGuards.tsx
@@ -1,0 +1,20 @@
+import { useAuthStore } from "@/stores/useAuthStore";
+import { useEffect } from "react";
+import { Navigate, Outlet } from "react-router-dom";
+
+export const PrivateRoute = () => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      alert("로그인이 필요한 서비스입니다.");
+    }
+  }, [isAuthenticated]);
+
+  // 비로그인 홈화면으로 리다이렉트
+  if (!isAuthenticated) {
+    return <Navigate to="/" replace state={{ openLogin: true }} />;
+  }
+
+  return <Outlet />;
+};

--- a/src/components/RouteGuards.tsx
+++ b/src/components/RouteGuards.tsx
@@ -4,12 +4,17 @@ import { Navigate, Outlet } from "react-router-dom";
 
 export const PrivateRoute = () => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (hasHydrated && !isAuthenticated) {
       alert("로그인이 필요한 서비스입니다.");
     }
-  }, [isAuthenticated]);
+  }, [hasHydrated, isAuthenticated]);
+
+  if (!hasHydrated) {
+    return null;
+  }
 
   // 비로그인 홈화면으로 리다이렉트
   if (!isAuthenticated) {

--- a/src/components/RouteGuards.tsx
+++ b/src/components/RouteGuards.tsx
@@ -1,16 +1,9 @@
 import { useAuthStore } from "@/stores/useAuthStore";
-import { useEffect } from "react";
 import { Navigate, Outlet } from "react-router-dom";
 
 export const PrivateRoute = () => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const hasHydrated = useAuthStore((state) => state.hasHydrated);
-
-  useEffect(() => {
-    if (hasHydrated && !isAuthenticated) {
-      alert("로그인이 필요한 서비스입니다.");
-    }
-  }, [hasHydrated, isAuthenticated]);
 
   if (!hasHydrated) {
     return null;

--- a/src/components/main/Header.tsx
+++ b/src/components/main/Header.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { LoginDialog } from "../auth/LoginDialog";
 import { SignupDialog } from "../auth/SignupDialog";
 import { Button } from "../ui/button";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useIsAuthenticated } from "@/stores/useAuthStore";
@@ -23,6 +23,18 @@ export default function Header() {
   const isAuthenticated = useIsAuthenticated();
 
   const nav = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.state?.openLogin) {
+      const timer = setTimeout(() => {
+        setLoginOpen(true);
+        nav(location.pathname, { replace: true, state: {} });
+      }, 0);
+
+      return () => clearTimeout(timer);
+    }
+  }, [location, nav]);
 
   const navItems: NavItem[] = useMemo(
     () => [

--- a/src/components/restaurant/RestaurantDetailModal.tsx
+++ b/src/components/restaurant/RestaurantDetailModal.tsx
@@ -1,6 +1,8 @@
 import type { Day, RestaurantDetail } from "@/types/store";
 import { Clock, Star, X } from "lucide-react";
 import { Button } from "../ui/button";
+import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "@/stores/useAuthStore";
 
 type Props = {
   open: boolean;
@@ -63,6 +65,19 @@ export default function RestaurantDetailModal({
   onRetry,
   onClickReserve,
 }: Props) {
+  const nav = useNavigate();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  const handleReserveClick = () => {
+    if (!isAuthenticated) {
+      alert("로그인이 필요한 서비스입니다.");
+      onOpenChange(false);
+      nav("/", { state: { openLogin: true } });
+      return;
+    }
+    onClickReserve();
+  };
+
   if (!open) return null;
 
   if (status === "idle" || status === "loading") {
@@ -257,7 +272,7 @@ export default function RestaurantDetailModal({
             <Button
               type="button"
               className="mt-5 text-md h-14 w-full cursor-pointer bg-blue-500 hover:bg-blue-600"
-              onClick={onClickReserve}
+              onClick={handleReserveClick}
             >
               식당 예약
             </Button>

--- a/src/components/restaurant/RestaurantDetailModal.tsx
+++ b/src/components/restaurant/RestaurantDetailModal.tsx
@@ -72,7 +72,7 @@ export default function RestaurantDetailModal({
     if (!isAuthenticated) {
       alert("로그인이 필요한 서비스입니다.");
       onOpenChange(false);
-      nav("/", { state: { openLogin: true } });
+      nav("/", { state: { openLogin: true }, replace: true });
       return;
     }
     onClickReserve();

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -6,6 +6,7 @@ interface AuthState {
   accessToken: string | null;
   isAuthenticated: boolean;
   userId: number | null;
+  hasHydrated: boolean;
 
   actions: {
     login: (token: string) => void;
@@ -21,6 +22,7 @@ export const useAuthStore = create<AuthState>()(
       accessToken: null,
       isAuthenticated: false,
       userId: null,
+      hasHydrated: false,
 
       actions: {
         login: (token) =>
@@ -50,6 +52,9 @@ export const useAuthStore = create<AuthState>()(
         isAuthenticated: state.isAuthenticated,
         userId: state.userId,
       }),
+      onRehydrateStorage: () => (state) => {
+        state!.hasHydrated = true;
+      },
     },
   ),
 );

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -52,8 +52,13 @@ export const useAuthStore = create<AuthState>()(
         isAuthenticated: state.isAuthenticated,
         userId: state.userId,
       }),
-      onRehydrateStorage: () => (state) => {
-        state!.hasHydrated = true;
+      onRehydrateStorage: () => (state, error) => {
+        if (error) {
+          console.error("Auth store rehydration failed:", error);
+        }
+        if (state) {
+          state.hasHydrated = true;
+        }
       },
     },
   ),


### PR DESCRIPTION
## 💡 개요
접근 제어 구현

## 🔢 관련 이슈 링크
- Closes #66

## 💻 작업내용
- 비로그인 유저의 접근을 차단하고 메인 페이지(/)로 리다이렉트하는 RouteGuards 컴포넌트 구현
- 식당 '예약하기' 버튼 클릭 시, 로그인 상태를 체크하여 비로그인 유저에게 알림을 띄우고 메인으로 이동시킴

## 📌 변경사항PR
- [x] FEAT: 새로운 기능 추가
- [ ] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [ ] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
-

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내페이지, 매장, 결제, 예약 등 특정 경로를 인증된 사용자 전용으로 이동
  * 보호된 페이지 접근 시 로그인 모달을 자동으로 열도록 리다이렉트 상태 전달
  * 예약 버튼 클릭 시 인증 여부 확인 후 흐름 진행(미인증 시 로그인 유도)
  * 공개 경로와 보호된 경로를 분리한 라우팅 구조 재조정
  * 인증 상태(hydration) 완료 전 렌더링 대기 처리 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->