### PR TITLE
feat: 마이페이지 비밀번호변경/회원탈퇴 API연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,16 +14,12 @@ import StoreRegistrationPage from "./pages/myPage/StoreRegistrationPage";
 import MyPageLayout from "./layouts/myPageLayout";
 import MyInfoPage from "./pages/myPage/myInfoPage";
 import SettingsPage from "./pages/myPage/settingPage";
-import PaymentPage from "./pages/myPage/paymentPage";
 import SubscriptionPage from "./pages/myPage/subscriptionPage";
 import ReservationPage from "./pages/myPage/reservationPage";
 import StorePage from "./pages/myPage/storePage";
 import OwnerPage from "./pages/ownerPage";
 import OAuthCallbackPage from "./pages/OAuthCallbackPage";
 import LoginErrorPage from "./pages/LoginErrorPage";
-import SuccessPage from "./pages/payment/SuccessPage";
-import FailPage from "./pages/payment/FailPage";
-import ReservationCompletePage from "./pages/ReservationCompletePage";
 
 const routes: RouteObject[] = [
   { path: "/oauth/callback", element: <OAuthCallbackPage /> },
@@ -40,7 +36,6 @@ const routes: RouteObject[] = [
           { index: true, element: <Navigate to="info" replace /> },
           { path: "info", element: <MyInfoPage /> },
           { path: "settings", element: <SettingsPage /> },
-          { path: "payment", element: <PaymentPage /> },
           { path: "subscription", element: <SubscriptionPage /> },
           { path: "reservations", element: <ReservationPage /> },
           { path: "store", element: <StorePage /> },
@@ -67,21 +62,6 @@ const routes: RouteObject[] = [
   {
     path: "/mypage/store/:storeId",
     element: <OwnerPage />,
-    errorElement: <NotFound />,
-  },
-  {
-    path: "/payment/success",
-    element: <SuccessPage />,
-    errorElement: <NotFound />,
-  },
-  {
-    path: "/payment/fail",
-    element: <FailPage />,
-    errorElement: <NotFound />,
-  },
-  {
-    path: "/reservation/complete",
-    element: <ReservationCompletePage />,
     errorElement: <NotFound />,
   },
   {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,17 +28,14 @@ import { PrivateRoute } from "./components/RouteGuards";
 const routes: RouteObject[] = [
   { path: "/oauth/callback", element: <OAuthCallbackPage /> },
   { path: "/login/error", element: <LoginErrorPage /> },
-  { path: "/",
-    element: <Intro />,
-    errorElement: <NotFound />,
-  },
+  { path: "/", element: <Intro />, errorElement: <NotFound /> },
 
   {
     path: "/customer-support",
     element: <CustomerSupportPage />,
     errorElement: <NotFound />,
   },
-
+  {
     element: <PublicLayout />,
     errorElement: <NotFound />,
     children: [
@@ -53,7 +50,6 @@ const routes: RouteObject[] = [
               { index: true, element: <Navigate to="info" replace /> },
               { path: "info", element: <MyInfoPage /> },
               { path: "settings", element: <SettingsPage /> },
-              { path: "payment", element: <PaymentPage /> },
               { path: "subscription", element: <SubscriptionPage /> },
               { path: "reservations", element: <ReservationPage /> },
               { path: "store", element: <StorePage /> },

--- a/src/api/endpoints/member.ts
+++ b/src/api/endpoints/member.ts
@@ -31,7 +31,7 @@ export type ChangePasswordResponse = {
   changeAt: string;
   message: string;
 };
-export async function putChangePassword(body: ChangePasswordResponse) {
+export async function putChangePassword(body: ChangePasswordRequest) {
   const res = await api.put<ApiEnvelope<ChangePasswordResponse>>(
     "/api/v1/member/password",
     body,

--- a/src/api/endpoints/member.ts
+++ b/src/api/endpoints/member.ts
@@ -19,3 +19,27 @@ export async function getMemberInfo() {
   const res = await api.get<ApiEnvelope<MemberInfo>>("/api/v1/member/info");
   return res.data.result;
 }
+
+export type ChangePasswordRequest = {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+};
+
+export type ChangePasswordResponse = {
+  change: boolean;
+  changeAt: string;
+  message: string;
+};
+export async function putChangePassword(body: ChangePasswordResponse) {
+  const res = await api.put<ApiEnvelope<ChangePasswordResponse>>(
+    "/api/v1/member/password",
+    body,
+  );
+  return res.data.result;
+}
+
+export async function deleteWithDraw() {
+  const res = await api.delete<string>(`/api/auth/withdraw`);
+  return res.data;
+}

--- a/src/api/endpoints/menus.ts
+++ b/src/api/endpoints/menus.ts
@@ -2,9 +2,10 @@ import type { MenuCategory, MenuItem } from "@/types/menus";
 import { api } from "../axios";
 
 type ApiResult<T> = {
-  isSuccess: boolean;
-  code: string;
-  message: string;
+  isSuccess?: boolean;
+  success?: boolean;
+  code?: string;
+  message?: string;
   result: T;
 };
 

--- a/src/components/auth/ChangePasswordDiaLog.tsx
+++ b/src/components/auth/ChangePasswordDiaLog.tsx
@@ -87,8 +87,11 @@ export function ChangePasswordDialog({
         </div>
         <form onSubmit={onSubmit} className="px-6 py-5 space-y-4">
           <div className="space-y-1">
-            <label className="text-sm font-medium">현재 비밀번호</label>
+            <label htmlFor="currentPassword" className="text-sm font-medium">
+              현재 비밀번호
+            </label>
             <input
+              id="currentPassword"
               type="password"
               autoComplete="current-password"
               className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"

--- a/src/components/auth/ChangePasswordDiaLog.tsx
+++ b/src/components/auth/ChangePasswordDiaLog.tsx
@@ -39,7 +39,7 @@ export function ChangePasswordDialog({
   const { mutate, isPending } = useMutation({
     mutationFn: putChangePassword,
     onSuccess: (result) => {
-      alert(result.message);
+      alert(result.message ?? "비밀번호가 변경되었습니다");
       form.reset();
       onOpenChange(false);
     },

--- a/src/components/auth/ChangePasswordDiaLog.tsx
+++ b/src/components/auth/ChangePasswordDiaLog.tsx
@@ -1,0 +1,156 @@
+import { putChangePassword } from "@/api/endpoints/member";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "../ui/button";
+import { X } from "lucide-react";
+
+const schema = z
+  .object({
+    currentPassword: z.string().min(1, "현재 비밀번호를 입력해주세요"),
+    newPassword: z.string().min(8, "비밀번호는 8자 이상이어야 합니다"),
+    newPasswordConfirm: z
+      .string()
+      .min(1, "변경하실 비밀번호를 한번더 눌러주세요"),
+  })
+  .refine((v) => v.newPassword === v.newPasswordConfirm, {
+    message: "새 비밀번호와 확인이 일치하지 않습니다.",
+    path: ["newPasswordConfirm"],
+  });
+
+type FormValues = z.infer<typeof schema>;
+
+export function ChangePasswordDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}) {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      currentPassword: "",
+      newPassword: "",
+      newPasswordConfirm: "",
+    },
+  });
+  const { mutate, isPending } = useMutation({
+    mutationFn: putChangePassword,
+    onSuccess: (result) => {
+      alert(result.message);
+      form.reset();
+      onOpenChange(false);
+    },
+    onError: (e: any) => {
+      const msg = e?.response?.data?.message ?? "비밀번호 변경에 실패했습니다.";
+      if (typeof msg === "string" && /현재|기존|일치|틀렸/.test(msg)) {
+        form.setError("currentPassword", { type: "server", message: msg });
+        return;
+      }
+      alert(msg);
+    },
+  });
+
+  const onSubmit = form.handleSubmit((values) => mutate(values));
+
+  const handleClose = () => {
+    form.reset();
+    onOpenChange(false);
+  };
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/40"
+        aria-label="모달 닫기"
+        onClick={handleClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-xl rounded-2xl shadow-xl border border-gray-100 bg-white p-4"
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+          <h3 className="text-lg font-semibold">비밀번호 변경</h3>
+          <button
+            type="button"
+            className="rounded-md px-2 py-1 text-gray-500 hover:bg-gray-100"
+            aria-label="닫기"
+            onClick={handleClose}
+          >
+            <X />
+          </button>
+        </div>
+        <form onSubmit={onSubmit} className="px-6 py-5 space-y-4">
+          <div className="space-y-1">
+            <label className="text-sm font-medium">현재 비밀번호</label>
+            <input
+              type="password"
+              autoComplete="current-password"
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+              {...form.register("currentPassword")}
+              disabled={isPending}
+            />
+            {form.formState.errors.currentPassword && (
+              <p className="text-sm text-red-500">
+                {form.formState.errors.currentPassword.message}
+              </p>
+            )}
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">새 비밀번호</label>
+            <input
+              type="password"
+              autoComplete="new-password"
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+              {...form.register("newPassword")}
+              disabled={isPending}
+            />
+            {form.formState.errors.newPassword && (
+              <p className="text-sm text-red-500">
+                {form.formState.errors.newPassword.message}
+              </p>
+            )}
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">새 비밀번호 확인</label>
+            <input
+              type="password"
+              autoComplete="new-password"
+              className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+              {...form.register("newPasswordConfirm")}
+              disabled={isPending}
+            />
+            {form.formState.errors.newPasswordConfirm && (
+              <p className="text-sm text-red-500">
+                {form.formState.errors.newPasswordConfirm.message}
+              </p>
+            )}
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="cursor-pointer hover:bg-gray-100"
+              onClick={handleClose}
+              disabled={isPending}
+            >
+              취소
+            </Button>
+            <Button
+              type="submit"
+              className="cursor-pointer bg-blue-500 hover:bg-blue-600 disabled:opacity-50"
+              disabled={isPending}
+            >
+              {isPending ? "변경중.. " : "변경하기"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/WithdrawDialog.tsx
+++ b/src/components/auth/WithdrawDialog.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "../ui/button";
 import { X } from "lucide-react";
 import { useState } from "react";
+import { logout as performLogout } from "@/api/auth";
 
 function isWithdrawBlockByBookings(e: any) {
   const msg = e?.response?.data?.message;
@@ -35,7 +36,7 @@ export function WithdrawDialog({
   onOpenChange: (v: boolean) => void;
 }) {
   const nav = useNavigate();
-  const logout = useAuthStore((logout: any) => logout);
+  const logout = useAuthStore((s) => s.actions.logout);
 
   const [blocked, setBlocked] = useState(false);
 
@@ -51,10 +52,8 @@ export function WithdrawDialog({
 
   const { mutate, isPending } = useMutation({
     mutationFn: deleteWithDraw,
-    onSuccess: () => {
-      try {
-        logout?.();
-      } catch {}
+    onSuccess: async () => {
+      await performLogout();
       alert("회원 탈퇴가 완료되었습니다.");
       onOpenChange(false);
       nav("/", { replace: true });

--- a/src/components/auth/WithdrawDialog.tsx
+++ b/src/components/auth/WithdrawDialog.tsx
@@ -1,0 +1,168 @@
+import { deleteWithDraw } from "@/api/endpoints/member";
+import { useAuthStore } from "@/stores/useAuthStore";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { Button } from "../ui/button";
+import { X } from "lucide-react";
+import { useState } from "react";
+
+function isWithdrawBlockByBookings(e: any) {
+  const msg = e?.response?.data?.message;
+  const result = e?.response?.data?.result;
+  const code = e?.response?.data?.code;
+
+  const raw = `${msg ?? ""} ${result ?? ""}`;
+
+  return (
+    code === "WITHDRAW_BLOCKED" ||
+    /foreign key constraint/i.test(raw) ||
+    /booking/i.test(raw) ||
+    /예약/i.test(raw)
+  );
+}
+
+// 백엔드 메세지 내려오면
+// function isWithdrawBlockBookings(e: any) {
+//   const code = e?.response?.data?.code;
+//   return code === "WITHDRAW_BLOCKED";
+// }
+
+export function WithdrawDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}) {
+  const nav = useNavigate();
+  const logout = useAuthStore((logout: any) => logout);
+
+  const [blocked, setBlocked] = useState(false);
+
+  const handleClose = () => {
+    setBlocked(false);
+    onOpenChange(false);
+  };
+  const goReservations = () => {
+    setBlocked(false);
+    onOpenChange(false);
+    nav("/mypage/reservations", { replace: true });
+  };
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: deleteWithDraw,
+    onSuccess: () => {
+      try {
+        logout?.();
+      } catch {}
+      alert("회원 탈퇴가 완료되었습니다.");
+      onOpenChange(false);
+      nav("/", { replace: true });
+    },
+    onError: (e: any) => {
+      if (isWithdrawBlockByBookings(e)) {
+        setBlocked(true);
+        return;
+      }
+      alert(e?.response?.data?.message ?? "회원 탈퇴에 실패했습니다.");
+    },
+  });
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <button
+        className="absolute inset-0 bg-black/40"
+        aria-label="모달 닫기"
+        onClick={handleClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-xl rounded-2xl shadow-xl border border-gray-100 bg-white p-4"
+      >
+        <div className=" flex items-center justify-between px-3 py-4 border-b border-gray-100">
+          <h3 className="text-xl font-semibold">
+            {blocked ? "탈퇴가 불가능합니다." : "정말 탈퇴하시겠어요?"}
+          </h3>
+          <button
+            type="button"
+            onClick={handleClose}
+            aria-label="닫기"
+            className="rounded-md px-2 py-1 text-gray-500 hover:bg-gray-100 cursor-pointer"
+          >
+            <X className="w-6 h-6" />
+          </button>
+        </div>
+
+        <div
+          key={blocked ? "blocked" : "confirm"}
+          className="px-6 py-5 space-y-2 font-medium text-lg animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-2 duration-200"
+        >
+          {blocked ? (
+            <>
+              <p className="text-red-500">
+                예약 내역이 있어 탈퇴가 불가능합니다.
+              </p>
+              <p className="text-muted-foreground">
+                예약 현황에서 예약을 취소한 후에 다시 시도해주세요.
+              </p>
+            </>
+          ) : (
+            <>
+              <p className="text-muted-foreground">
+                탈퇴하면 계정과 데이터가 영구적으로 삭제됩니다.
+              </p>
+              <p className="text-red-500">삭제한 계정은 되돌릴 수 없습니다.</p>
+            </>
+          )}
+        </div>
+        <div
+          key={blocked ? "blocked-button" : "confirm-button"}
+          className="flex justify-end gap-3 my-4 mr-5 animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-2 duration-200"
+        >
+          {blocked ? (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                className="cursor-pointer bg-gray-100 hover:bg-gray-200"
+                onClick={handleClose}
+              >
+                취소
+              </Button>
+              <Button
+                type="button"
+                className="cursor-pointer bg-blue-500 hover:bg-blue-600"
+                onClick={goReservations}
+              >
+                예약 목록으로 이동
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                className="cursor-pointer bg-gray-100 hover:bg-gray-200"
+                onClick={handleClose}
+                disabled={isPending}
+              >
+                취소
+              </Button>
+              <Button
+                type="button"
+                className="cursor-pointer bg-red-500 hover:bg-red-700 disabled:opacity-50"
+                onClick={() => mutate()}
+                disabled={isPending}
+              >
+                {isPending ? "처리중.." : "탈퇴하기"}
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/WithdrawDialog.tsx
+++ b/src/components/auth/WithdrawDialog.tsx
@@ -22,8 +22,8 @@ function isWithdrawBlockByBookings(e: any) {
   );
 }
 
-// 백엔드 메세지 내려오면
-// function isWithdrawBlockBookings(e: any) {
+// 백엔드 배포완료되면
+// function isWithdrawBlockByBookings(e: any) {
 //   const code = e?.response?.data?.code;
 //   return code === "WITHDRAW_BLOCKED";
 // }
@@ -53,7 +53,12 @@ export function WithdrawDialog({
   const { mutate, isPending } = useMutation({
     mutationFn: deleteWithDraw,
     onSuccess: async () => {
-      await performLogout();
+      try {
+        await performLogout();
+      } finally {
+        logout();
+      }
+
       alert("회원 탈퇴가 완료되었습니다.");
       onOpenChange(false);
       nav("/", { replace: true });
@@ -111,9 +116,11 @@ export function WithdrawDialog({
           ) : (
             <>
               <p className="text-muted-foreground">
-                탈퇴하면 계정과 데이터가 영구적으로 삭제됩니다.
+                탈퇴하면 계정이 비활성화되며 서비스 이용이 불가합니다.
               </p>
-              <p className="text-red-500">삭제한 계정은 되돌릴 수 없습니다.</p>
+              <p className="text-red-500">
+                탈퇴후에는 동일 계정으로 다시 로그인할 수 없습니다.
+              </p>
             </>
           )}
         </div>

--- a/src/pages/myPage/myInfoPage.tsx
+++ b/src/pages/myPage/myInfoPage.tsx
@@ -54,8 +54,8 @@ export default function MyInfoPage() {
   const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setDraftImageFile(file); //TODO: 서버 업로드에 사용
-    e.target.value = ""; //같은 파일 재선택 가능하도록 설정
+    setDraftImageFile(file);
+    e.target.value = "";
   };
 
   const isValidPhone = (value: string) => {

--- a/src/pages/myPage/settingPage.tsx
+++ b/src/pages/myPage/settingPage.tsx
@@ -1,9 +1,12 @@
 import { Lock, Bell, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
+import { ChangePasswordDialog } from "@/components/auth/ChangePasswordDiaLog";
+import { WithdrawDialog } from "@/components/auth/WithdrawDialog";
 
 export default function SettingsPage() {
-  // 알림 설정을 위한 상태 관리
+  const [pwOpen, setPwOpen] = useState(false);
+  const [withdrawOpen, setWithdrawOpen] = useState(false);
   const [notifications, setNotifications] = useState({
     reservation: true,
     promotion: true,
@@ -32,7 +35,10 @@ export default function SettingsPage() {
               정기적인 비밀번호 변경으로 계정을 안전하게 보호하세요
             </p>
           </div>
-          <button className="cursor-pointer rounded-lg border border-gray-200 px-4 py-2 font-medium text-gray-700 hover:bg-gray-50 transition-colors">
+          <button
+            className="cursor-pointer rounded-lg border border-gray-200 px-4 py-2 font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+            onClick={() => setPwOpen(true)}
+          >
             비밀번호 변경하기
           </button>
         </div>
@@ -106,9 +112,14 @@ export default function SettingsPage() {
               계정을 삭제하면 모든 데이터가 영구적으로 삭제됩니다
             </p>
           </div>
-          <button className="cursor-pointer rounded-lg border border-red-500 px-4 py-2 font-medium text-red-600 hover:bg-red-50 transition-colors">
+          <button
+            className="cursor-pointer rounded-lg border border-red-500 px-4 py-2 font-medium text-red-600 hover:bg-red-50 transition-colors"
+            onClick={() => setWithdrawOpen(true)}
+          >
             계정 탈퇴하기
           </button>
+          <ChangePasswordDialog open={pwOpen} onOpenChange={setPwOpen} />
+          <WithdrawDialog open={withdrawOpen} onOpenChange={setWithdrawOpen} />
         </div>
       </div>
     </section>

--- a/src/utils/phoneNumber.ts
+++ b/src/utils/phoneNumber.ts
@@ -1,17 +1,23 @@
 export function phoneNumber(value: string) {
-  const numbers = value.replace(/\D/g, "").slice(0, 11);;
+  const numbers = value.replace(/\D/g, "").slice(0, 11);
 
   // 서울 지역번호
   if (numbers.startsWith("02")) {
-    if (numbers.length <= 2) return numbers;
-    if (numbers.length <= 6) return numbers.replace(/(\d{2})(\d+)/, "$1-$2");
-    if (numbers.length <= 9) return numbers.replace(/(\d{2})(\d{3})(\d+)/, "$1-$2-$3");
-    return numbers.replace(/(\d{2})(\d{4})(\d{4})/, "$1-$2-$3");
+    const seoulNumbers = numbers.slice(0, 10);
+    if (seoulNumbers.length <= 2) return seoulNumbers;
+    if (seoulNumbers.length <= 6)
+      return seoulNumbers.replace(/(\d{2})(\d+)/, "$1-$2");
+    if (seoulNumbers.length <= 9)
+      return seoulNumbers.replace(/(\d{2})(\d{3})(\d+)/, "$1-$2-$3");
+    return seoulNumbers.replace(/(\d{2})(\d{4})(\d{4})/, "$1-$2-$3");
   }
 
   // 기타 지역 / 휴대폰
-  if (numbers.length <= 3) return numbers;
-  if (numbers.length <= 7) return numbers.replace(/(\d{3})(\d+)/, "$1-$2");
-  if (numbers.length <= 10) return numbers.replace(/(\d{3})(\d{3})(\d+)/, "$1-$2-$3");
-  return numbers.replace(/(\d{3})(\d{4})(\d{4})/, "$1-$2-$3");
+  const otherNumbers = numbers.slice(0, 11);
+  if (otherNumbers.length <= 3) return otherNumbers;
+  if (otherNumbers.length <= 7)
+    return otherNumbers.replace(/(\d{3})(\d+)/, "$1-$2");
+  if (otherNumbers.length <= 10)
+    return otherNumbers.replace(/(\d{3})(\d{3})(\d+)/, "$1-$2-$3");
+  return otherNumbers.replace(/(\d{3})(\d{4})(\d{4})/, "$1-$2-$3");
 }


### PR DESCRIPTION
## 💡 개요
SettingPage에서 비밀번호 변경 및 회원탈퇴 기능 API연동하고, 성공/실패에 따라서 UI/상태처리 추가했습니다.

## 🔢 관련 이슈 링크
- Closes #70 

## 💻 작업내용
- SettingPage 비밀번호 변경 API 연동 및 요청/응답 처리
- 비밀번호 변경 입력값 검증 및 에러 메세지 표시
- 회원 탈퇴 API 연동 및 요청/응답 처리
- 회원 탈퇴 전 안내사항 추가
- 회원 탈퇴 성공시 인증 토큰/전역 상태 초기화 및 페이지 이동 처리
- 공통 예외 처리(로딩, 에러, 실패) 추가

## 📌 변경사항PR
- [x] FEAT: 새로운 기능 추가
- [ ] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [ ] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
- 지금 회원탈퇴 부분 에러메세지 미작동은 백엔드에 문의중입니다

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 설정에 비밀번호 변경 다이얼로그 추가
  * 계정 탈퇴 다이얼로그 추가(진행 중 예약으로 제한 여부 안내 및 처리 흐름 포함)

* **제거된 기능**
  * 결제 관련 페이지 및 경로 삭제(마이페이지 및 최상위의 결제/예약 완료 관련 경로 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->