### PR TITLE
fix: 마이페이지 내 결제수단 관리 탭 삭제

### DIFF
--- a/src/layouts/myPageLayout.tsx
+++ b/src/layouts/myPageLayout.tsx
@@ -1,18 +1,10 @@
 import { Outlet, NavLink } from "react-router-dom";
-import {
-  Calendar,
-  CreditCard,
-  Crown,
-  Settings,
-  Store,
-  User,
-} from "lucide-react";
+import { Calendar, Crown, Settings, Store, User } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const sidebarItems = [
   { to: "/mypage/info", label: "내 정보", icon: User },
   { to: "/mypage/settings", label: "계정 설정", icon: Settings },
-  { to: "/mypage/payment", label: "결제수단", icon: CreditCard },
   { to: "/mypage/subscription", label: "구독 관리", icon: Crown },
   { to: "/mypage/reservations", label: "예약 현황", icon: Calendar },
   { to: "/mypage/store", label: "내 가게 관리", icon: Store },


### PR DESCRIPTION
## 💡 개요
마이페이지 내에 결제수단 관리 탭 레이아웃 삭제

## 🔢 관련 이슈 링크
- Closes #72 

## 💻 작업내용
- 결제수단 관리를 토스페이먼츠를 도입하면서 필요없다고 판단되어 삭제를 진행했었으나, 레이아웃은 삭제를 안해서 틀은 존재하지만, 안에 내용은 Notfound로 가게 되는 상황이었음.
- 그래서 UI에서도 삭제 진행

## 📌 변경사항PR
- [ ] FEAT: 새로운 기능 추가
- [x] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [ ] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
- N/A

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **기능 변경**
  * 마이페이지 사이드바 네비게이션에서 결제수단 메뉴 항목이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->