### PR TITLE
feat: 사업자 인증 대표자명 필드 추가, 예외 처리 보완

### DIFF
--- a/src/components/store-registration/BusinessAuth.schema.ts
+++ b/src/components/store-registration/BusinessAuth.schema.ts
@@ -1,6 +1,11 @@
 import z from "zod";
 
 export const BusinessAuthSchema = z.object({
+  name: z
+    .string()
+    .min(1, "대표자명을 입력해주세요.")
+    .min(2, "2자 이상이어야 합니다.")
+    .max(20, "20자 이하이어야 합니다."),
   businessNumber: z
     .string()
     .regex(/^[0-9]+$/, "숫자만 입력해주세요.")

--- a/src/components/store-registration/ConfirmModal.tsx
+++ b/src/components/store-registration/ConfirmModal.tsx
@@ -5,35 +5,60 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import type { ReactNode } from "react";
 
 interface ConfirmModalProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
+  title?: string;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "danger" | "primary";
 }
 
 export default function ConfirmModal({
   isOpen,
   onClose,
   onConfirm,
+  title = "가게 등록을 그만두시겠습니까?",
+  description = (
+    <>
+      작성 중인 내용은 저장되지 않습니다.
+      <br />
+      정말 새 가게 등록을 그만두시겠습니까?
+    </>
+  ),
+  confirmLabel = "예",
+  cancelLabel = "아니오",
+  variant = "danger",
 }: ConfirmModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent showCloseButton={false} className="sm:max-w-[440px]">
         <DialogHeader className="flex flex-col items-center justify-center text-center">
-          <DialogTitle>가게 등록을 그만두시겠습니까?</DialogTitle>
+          <DialogTitle>{title}</DialogTitle>
           <DialogDescription className="text-center mt-2">
-            작성 중인 내용은 저장되지 않습니다.
-            <br />
-            정말 새 가게 등록을 그만두시겠습니까?
+            {description}
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-row items-center justify-center w-full gap-6 mt-4">
-          <button onClick={onConfirm} className="flex-1 py-2 text-white bg-red-500 rounded-lg hover:bg-red-600 transition-colors cursor-pointer">
-            예
+          <button
+            onClick={onConfirm}
+            className={`flex-1 py-2 text-white rounded-lg transition-colors cursor-pointer ${
+              variant === "danger"
+                ? "bg-red-500 hover:bg-red-600"
+                : "bg-blue-500 hover:bg-blue-600"
+            }`}
+          >
+            {confirmLabel}
           </button>
-          <button onClick={onClose} className="flex-1 py-2 text-gray-700 bg-gray-300 rounded-lg hover:bg-gray-400 transition-colors cursor-pointer">
-            아니오
+          <button
+            onClick={onClose}
+            className="flex-1 py-2 text-gray-700 bg-gray-300 rounded-lg hover:bg-gray-400 transition-colors cursor-pointer"
+          >
+            {cancelLabel}
           </button>
         </div>
       </DialogContent>

--- a/src/components/store-registration/ConfirmModal.tsx
+++ b/src/components/store-registration/ConfirmModal.tsx
@@ -45,6 +45,7 @@ export default function ConfirmModal({
         </DialogHeader>
         <div className="flex flex-row items-center justify-center w-full gap-6 mt-4">
           <button
+            type="button"
             onClick={onConfirm}
             className={`flex-1 py-2 text-white rounded-lg transition-colors cursor-pointer ${
               variant === "danger"
@@ -55,6 +56,7 @@ export default function ConfirmModal({
             {confirmLabel}
           </button>
           <button
+            type="button"
             onClick={onClose}
             className="flex-1 py-2 text-gray-700 bg-gray-300 rounded-lg hover:bg-gray-400 transition-colors cursor-pointer"
           >

--- a/src/components/store-registration/StepBusinessAuth.tsx
+++ b/src/components/store-registration/StepBusinessAuth.tsx
@@ -272,7 +272,12 @@ export default function StepBusinessAuth({
         </div>
 
         {!isPending && isVerified && (
-          <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="bg-green-50 border border-green-200 rounded-lg p-4"
+          >
             <div className="flex items-center gap-2 text-green-800">
               <Check className="size-5" aria-hidden="true" />
               <span>사업자등록번호가 인증되었습니다.</span>

--- a/src/components/store-registration/StepBusinessAuth.tsx
+++ b/src/components/store-registration/StepBusinessAuth.tsx
@@ -162,10 +162,21 @@ export default function StepBusinessAuth({
               type="text"
               placeholder="대표자명을 입력해주세요."
               maxLength={20}
+              aria-required="true"
+              aria-describedby={
+                errors.name && touchedFields.name ? "name-error" : undefined
+              }
+              aria-invalid={!!(errors.name && touchedFields.name)}
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             {errors.name && touchedFields.name && (
-              <p className="text-red-500 text-xs mt-2">{errors.name.message}</p>
+              <p
+                id="name-error"
+                role="alert"
+                className="text-red-500 text-xs mt-2"
+              >
+                {errors.name.message}
+              </p>
             )}
           </div>
           <div>
@@ -194,10 +205,23 @@ export default function StepBusinessAuth({
               type="text"
               placeholder="10자리 숫자를 입력해주세요."
               maxLength={10}
+              aria-required="true"
+              aria-describedby={
+                errors.businessNumber && touchedFields.businessNumber
+                  ? "businessNumber-error"
+                  : undefined
+              }
+              aria-invalid={
+                !!(errors.businessNumber && touchedFields.businessNumber)
+              }
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             {errors.businessNumber && touchedFields.businessNumber && (
-              <p className="text-red-500 text-xs mt-2">
+              <p
+                id="businessNumber-error"
+                role="alert"
+                className="text-red-500 text-xs mt-2"
+              >
                 {errors.businessNumber.message}
               </p>
             )}
@@ -226,10 +250,21 @@ export default function StepBusinessAuth({
               inputMode="numeric"
               placeholder="8자리 숫자를 입력해주세요."
               maxLength={8}
+              aria-required="true"
+              aria-describedby={
+                errors.startDate && touchedFields.startDate
+                  ? "startDate-error"
+                  : undefined
+              }
+              aria-invalid={!!(errors.startDate && touchedFields.startDate)}
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 outline-none"
             />
             {errors.startDate && touchedFields.startDate && (
-              <p className="text-red-500 text-xs mt-2">
+              <p
+                id="startDate-error"
+                role="alert"
+                className="text-red-500 text-xs mt-2"
+              >
                 {errors.startDate.message}
               </p>
             )}

--- a/src/components/store-registration/StepBusinessAuth.tsx
+++ b/src/components/store-registration/StepBusinessAuth.tsx
@@ -11,6 +11,7 @@ import { useVerifyOwner } from "@/hooks/queries/useAuth";
 import { getErrorMessage } from "@/utils/error";
 import { useNavigate } from "react-router-dom";
 import { logout } from "@/api/auth";
+import ConfirmModal from "./ConfirmModal";
 
 interface StepBusinessAuthProps {
   defaultValues: {
@@ -32,6 +33,10 @@ export default function StepBusinessAuth({
   onComplete,
 }: StepBusinessAuthProps) {
   const { mutate: verifyOwner, isPending } = useVerifyOwner();
+
+  const [pendingData, setPendingData] = useState<BusinessAuthFormValues | null>(
+    null,
+  );
 
   const [isVerified, setIsVerified] = useState(defaultValues.isVerified);
   const isMountedRef = useRef(true);
@@ -75,22 +80,7 @@ export default function StepBusinessAuth({
         const err = error as any;
         const serverCode = err.response?.data?.code || err.code;
         if (serverCode === "OWNER409") {
-          const isConfirmed = confirm(
-            "이미 인증된 계정입니다.\n\n" +
-              "지금 입력하신 사업자 정보로 가게 등록을 진행하시겠습니까?\n" +
-              "(정보가 정확하지 않으면 최종 등록이 되지 않을 수 있습니다.)",
-          );
-          if (isConfirmed) {
-            setIsVerified(true);
-            onComplete({
-              name: data.name,
-              businessNumber: data.businessNumber,
-              startDate: data.startDate,
-              isVerified: true,
-            });
-          } else {
-            setIsVerified(false);
-          }
+          setPendingData(data);
           return;
         }
         setIsVerified(false);
@@ -99,135 +89,178 @@ export default function StepBusinessAuth({
     });
   };
 
+  const handleConfirm409 = () => {
+    if (!pendingData) return;
+    setIsVerified(true);
+    onComplete({
+      name: pendingData.name,
+      businessNumber: pendingData.businessNumber,
+      startDate: pendingData.startDate,
+      isVerified: true,
+    });
+    setPendingData(null);
+  };
+
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="max-w-md mx-auto space-y-6 sm:space-y-8"
-    >
-      <div>
-        <h3 className="text-gray-900 mb-2">사업자등록번호 인증</h3>
-        <p className="text-gray-600 text-sm">
-          사업자등록번호를 입력하고 인증을 진행해주세요.
-        </p>
-      </div>
-      <div className="space-y-3">
+    <>
+      <ConfirmModal
+        isOpen={!!pendingData}
+        onClose={() => {
+          setPendingData(null);
+          setIsVerified(false);
+        }}
+        onConfirm={handleConfirm409}
+        title="이미 인증된 계정입니다"
+        description={
+          <>
+            지금 입력하신 사업자 정보가
+            <br />
+            정확한지 다시 한번 확인해 주세요.
+            <br />
+            입력하신 정보로 진행하시겠습니까?
+            <br />
+            <br />
+            <span className="text-black  font-bold">
+              정보가 다르면 새 가게 등록에 실패할 수 있습니다.
+            </span>
+          </>
+        }
+        confirmLabel="네, 진행합니다"
+        cancelLabel="취소"
+        variant="primary"
+      />
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="max-w-md mx-auto space-y-6 sm:space-y-8"
+      >
         <div>
-          <Label htmlFor="name" className="block text-gray-700 mb-2">
-            대표자명 <span className="text-red-500">*</span>
-          </Label>
-          <input
-            id="name"
-            {...register("name", {
-              onChange: (e) => {
-                if (isVerified) {
-                  setIsVerified(false);
-                  onComplete({
-                    name: e.target.value,
-                    businessNumber,
-                    startDate,
-                    isVerified: false,
-                  });
-                }
-              },
-            })}
-            type="text"
-            placeholder="대표자명을 입력해주세요."
-            maxLength={20}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-          {errors.name && touchedFields.name && (
-            <p className="text-red-500 text-xs mt-2">{errors.name.message}</p>
-          )}
+          <h3 className="text-gray-900 mb-2">사업자등록번호 인증</h3>
+          <p className="text-gray-600 text-sm">
+            사업자등록번호를 입력하고 인증을 진행해주세요.
+          </p>
         </div>
-        <div>
-          <Label htmlFor="businessNumber" className="block text-gray-700 mb-2">
-            사업자등록번호 <span className="text-red-500">*</span>
-          </Label>
-          <input
-            id="businessNumber"
-            inputMode="numeric"
-            {...register("businessNumber", {
-              onChange: (e) => {
-                if (isVerified) {
-                  setIsVerified(false);
-                  onComplete({
-                    name,
-                    businessNumber: e.target.value,
-                    startDate,
-                    isVerified: false,
-                  });
-                }
-              },
-            })}
-            type="text"
-            placeholder="10자리 숫자를 입력해주세요."
-            maxLength={10}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-          {errors.businessNumber && touchedFields.businessNumber && (
-            <p className="text-red-500 text-xs mt-2">
-              {errors.businessNumber.message}
-            </p>
-          )}
-        </div>
+        <div className="space-y-3">
+          <div>
+            <Label htmlFor="name" className="block text-gray-700 mb-2">
+              대표자명 <span className="text-red-500">*</span>
+            </Label>
+            <input
+              id="name"
+              {...register("name", {
+                onChange: (e) => {
+                  if (isVerified) {
+                    setIsVerified(false);
+                    onComplete({
+                      name: e.target.value,
+                      businessNumber,
+                      startDate,
+                      isVerified: false,
+                    });
+                  }
+                },
+              })}
+              type="text"
+              placeholder="대표자명을 입력해주세요."
+              maxLength={20}
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.name && touchedFields.name && (
+              <p className="text-red-500 text-xs mt-2">{errors.name.message}</p>
+            )}
+          </div>
+          <div>
+            <Label
+              htmlFor="businessNumber"
+              className="block text-gray-700 mb-2"
+            >
+              사업자등록번호 <span className="text-red-500">*</span>
+            </Label>
+            <input
+              id="businessNumber"
+              inputMode="numeric"
+              {...register("businessNumber", {
+                onChange: (e) => {
+                  if (isVerified) {
+                    setIsVerified(false);
+                    onComplete({
+                      name,
+                      businessNumber: e.target.value,
+                      startDate,
+                      isVerified: false,
+                    });
+                  }
+                },
+              })}
+              type="text"
+              placeholder="10자리 숫자를 입력해주세요."
+              maxLength={10}
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.businessNumber && touchedFields.businessNumber && (
+              <p className="text-red-500 text-xs mt-2">
+                {errors.businessNumber.message}
+              </p>
+            )}
+          </div>
 
-        <div>
-          <Label htmlFor="startDate" className="block text-gray-700 mb-2">
-            개업일자 <span className="text-red-500">*</span>
-          </Label>
-          <input
-            id="startDate"
-            {...register("startDate", {
-              onChange: (e) => {
-                if (isVerified) {
-                  setIsVerified(false);
-                  onComplete({
-                    name,
-                    businessNumber,
-                    startDate: e.target.value,
-                    isVerified: false,
-                  });
-                }
-              },
-            })}
-            type="text"
-            inputMode="numeric"
-            placeholder="8자리 숫자를 입력해주세요."
-            maxLength={8}
-            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 outline-none"
-          />
-          {errors.startDate && touchedFields.startDate && (
-            <p className="text-red-500 text-xs mt-2">
-              {errors.startDate.message}
-            </p>
-          )}
-        </div>
-      </div>
-
-      {!isPending && isVerified && (
-        <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-          <div className="flex items-center gap-2 text-green-800">
-            <Check className="size-5" aria-hidden="true" />
-            <span>사업자등록번호가 인증되었습니다.</span>
+          <div>
+            <Label htmlFor="startDate" className="block text-gray-700 mb-2">
+              개업일자 <span className="text-red-500">*</span>
+            </Label>
+            <input
+              id="startDate"
+              {...register("startDate", {
+                onChange: (e) => {
+                  if (isVerified) {
+                    setIsVerified(false);
+                    onComplete({
+                      name,
+                      businessNumber,
+                      startDate: e.target.value,
+                      isVerified: false,
+                    });
+                  }
+                },
+              })}
+              type="text"
+              inputMode="numeric"
+              placeholder="8자리 숫자를 입력해주세요."
+              maxLength={8}
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 outline-none"
+            />
+            {errors.startDate && touchedFields.startDate && (
+              <p className="text-red-500 text-xs mt-2">
+                {errors.startDate.message}
+              </p>
+            )}
           </div>
         </div>
-      )}
 
-      <button
-        type="submit"
-        disabled={isPending || !isValid || isVerified}
-        className="w-full px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed whitespace-nowrap cursor-pointer"
-      >
-        {isPending ? (
-          <span className="flex items-center justify-center gap-2">
-            확인 중...
-          </span>
-        ) : isVerified ? (
-          "인증 완료"
-        ) : (
-          "인증하기"
+        {!isPending && isVerified && (
+          <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+            <div className="flex items-center gap-2 text-green-800">
+              <Check className="size-5" aria-hidden="true" />
+              <span>사업자등록번호가 인증되었습니다.</span>
+            </div>
+          </div>
         )}
-      </button>
-    </form>
+
+        <button
+          type="submit"
+          disabled={isPending || !isValid || isVerified}
+          className="w-full px-6 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed whitespace-nowrap cursor-pointer"
+        >
+          {isPending ? (
+            <span className="flex items-center justify-center gap-2">
+              확인 중...
+            </span>
+          ) : isVerified ? (
+            "인증 완료"
+          ) : (
+            "인증하기"
+          )}
+        </button>
+      </form>
+    </>
   );
 }

--- a/src/components/store-registration/StepBusinessAuth.tsx
+++ b/src/components/store-registration/StepBusinessAuth.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Label } from "@radix-ui/react-label";
+import { Label } from "@/components/ui/label";
 import { Check } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";

--- a/src/components/store-registration/StoreTransform.utils.ts
+++ b/src/components/store-registration/StoreTransform.utils.ts
@@ -44,7 +44,7 @@ const formatCoordinate = (
 };
 
 export const transformToRegister = (
-  step1Data: { businessNumber: string; startDate: string },
+  step1Data: { name: string; businessNumber: string; startDate: string },
   step2Data: StoreInfoFormValues,
 ): RequestStoreCreateDto => {
   const {
@@ -84,6 +84,7 @@ export const transformToRegister = (
   return {
     storeName: step2Data.storeName,
     businessNumberDto: {
+      name: step1Data.name,
       businessNumber: step1Data.businessNumber,
       startDate: step1Data.startDate,
     },

--- a/src/pages/myPage/StoreRegistrationPage.tsx
+++ b/src/pages/myPage/StoreRegistrationPage.tsx
@@ -17,6 +17,7 @@ import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 type Step1Data = {
+  name: string;
   businessNumber: string;
   startDate: string;
   isVerified: boolean;
@@ -36,6 +37,7 @@ export default function StoreRegistrationPage() {
   const [currentStep, setCurrentStep] = useState<1 | 2 | 3>(1);
 
   const [step1Data, setStep1Data] = useState<Step1Data>({
+    name: "",
     businessNumber: "",
     startDate: "",
     isVerified: false,

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -69,6 +69,7 @@ export const categoryLabel: Record<Category, string> = {
 export type DepositRate = "TEN" | "TWENTY" | "THIRTY" | "FORTY" | "FIFTY";
 
 export type BusinessNumberDto = {
+  name:string;
   businessNumber: string;
   startDate: string;
 };


### PR DESCRIPTION
## 💡 개요
사업자 인증 대표자명 필드 추가, 예외 처리 보완

## 🔢 관련 이슈 링크
- Closes #102 

## 💻 작업내용
- 사업자 인증 대표자명 필드 추가
- 이미 인증받은 회원이 인증 시도할 경우 confirm 모달을 띄워 현재 입력한 정보가 정확한지 사용자가 재확인하도록 수정

## 📌 변경사항PR
- [x] FEAT: 새로운 기능 추가
- [ ] FIX: 버그/오류 수정
- [x] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [ ] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
- N/A

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사업자 인증 단계에 대표자명 입력 필드 추가(2자 이상, 20자 이하).

* **개선 사항**
  * 중복 소유자(409) 발생 시 알림을 확인 대화상자로 대체 — 사용자가 확인하면 절차가 이어지고 입력한 대표자명이 반영됩니다.
  * 등록 요청 흐름에 대표자명 포함으로 전송 정보 확장.
  * 확인 대화상자에 제목·설명·버튼 레이블 및 스타일 옵션 추가로 표시 유연성 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->