### PR TITLE
fix: 가게 검색시 좌표 응답 매핑 추가

### DIFF
--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -20,6 +20,28 @@ declare global {
   }
 }
 
+const toNum = (v: unknown) => {
+  const n = typeof v === "string" ? parseFloat(v) : Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+const normalizeLatLng = (loc: any): LatLng | null => {
+  if (!loc) return null;
+
+  let lat = toNum(loc.lat);
+  let lng = toNum(loc.lng);
+
+  if (lat == null || lng == null) return null;
+
+  if (Math.abs(lat) > 90 && Math.abs(lng) <= 90) {
+    const tmp = lat;
+    lat = lng;
+    lng = tmp;
+  }
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
+  return { lat, lng };
+};
+
 export default function KakaoMap({
   center,
   markers,
@@ -34,28 +56,6 @@ export default function KakaoMap({
   const markersRef = useRef<Map<number, any>>(new Map());
   const infoRef = useRef<any>(null);
   const prevSelectedIdRef = useRef<number | null>(null);
-
-  const toNum = (v: unknown) => {
-    const n = typeof v === "string" ? parseFloat(v) : Number(v);
-    return Number.isFinite(n) ? n : null;
-  };
-
-  const normalizeLatLng = (loc: any): LatLng | null => {
-    if (!loc) return null;
-
-    let lat = toNum(loc.lat);
-    let lng = toNum(loc.lng);
-
-    if (lat == null || lng == null) return null;
-
-    if (Math.abs(lat) > 90 && Math.abs(lng) <= 90) {
-      const tmp = lat;
-      lat = lng;
-      lng = tmp;
-    }
-    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) return null;
-    return { lat, lng };
-  };
 
   const safeMarkers = useMemo<MarkerWithLocation[]>(() => {
     return markers
@@ -241,6 +241,8 @@ export default function KakaoMap({
   return (
     <div
       ref={containerRef}
+      role="region"
+      aria-label="레스토랑 위치 지도"
       className={
         className ??
         "relative w-full h-125 bg-gray-100 rounded-xl overflow-hidden"

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -3,6 +3,7 @@ import type { RestaurantSummary } from "@/types/store";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 type LatLng = { lat: number; lng: number };
+type MarkerWithLocation = RestaurantSummary & { location: LatLng };
 
 type Props = {
   center: LatLng;
@@ -56,14 +57,14 @@ export default function KakaoMap({
     return { lat, lng };
   };
 
-  const safeMarkers = useMemo(() => {
+  const safeMarkers = useMemo<MarkerWithLocation[]>(() => {
     return markers
       .map((m) => {
         const norm = normalizeLatLng((m as any).location);
         if (!norm) return null;
-        return { ...m, location: norm };
+        return { ...m, location: norm } as MarkerWithLocation;
       })
-      .filter(Boolean) as RestaurantSummary[];
+      .filter(Boolean) as MarkerWithLocation[];
   }, [markers]);
 
   const [sdkReady, setSdkReady] = useState(!!window.kakao?.maps);

--- a/src/hooks/store/useSearchStores.ts
+++ b/src/hooks/store/useSearchStores.ts
@@ -23,9 +23,11 @@ type ApiStoreSummary = {
   category: RestaurantSummary["category"];
   rating: number | null;
   reviewCount: number | null;
-  distanceKm?: number | null;
-  thumbnailUrl?: string | null;
+  distance?: number | null;
+  mainImageUrl?: string | null;
   isOpenNow?: boolean | null;
+  latitude?: number | string | null;
+  longitude?: number | string | null;
   lat: number;
   lng: number;
 };
@@ -46,7 +48,14 @@ type ApiResponse = {
   };
 };
 
+const toNum = (v: unknown) => {
+  const n = typeof v === "string" ? parseFloat(v) : Number(v);
+  return Number.isFinite(n) ? n : undefined;
+};
+
 function toSummary(s: ApiStoreSummary): RestaurantSummary {
+  const lat = toNum(s.latitude ?? s.lat);
+  const lng = toNum(s.longitude ?? s.lng);
   return {
     id: s.storeId,
     name: s.name,
@@ -54,10 +63,10 @@ function toSummary(s: ApiStoreSummary): RestaurantSummary {
     category: s.category,
     rating: typeof s.rating === "number" ? s.rating : 0,
     reviewCount: typeof s.reviewCount === "number" ? s.reviewCount : 0,
-    distanceKm: s.distanceKm ?? undefined,
-    thumbnailUrl: s.thumbnailUrl ?? undefined,
+    distanceKm: typeof s.distance === "number" ? s.distance : undefined,
+    thumbnailUrl: (s.mainImageUrl ?? undefined) || undefined,
     isOpenNow: s.isOpenNow ?? undefined,
-    location: { lat: s.lat, lng: s.lng },
+    location: { lat: lat ?? NaN, lng: lng ?? NaN },
   };
 }
 

--- a/src/hooks/store/useSearchStores.ts
+++ b/src/hooks/store/useSearchStores.ts
@@ -48,7 +48,8 @@ type ApiResponse = {
   };
 };
 
-const toNum = (v: unknown) => {
+const toNum = (v: unknown): number | undefined => {
+  if (v == null) return undefined;
   const n = typeof v === "string" ? parseFloat(v) : Number(v);
   return Number.isFinite(n) ? n : undefined;
 };

--- a/src/hooks/store/useSearchStores.ts
+++ b/src/hooks/store/useSearchStores.ts
@@ -1,5 +1,5 @@
 import { api } from "@/api/axios";
-import type { RestaurantSummary } from "@/types/store";
+import type { Category, RestaurantSummary } from "@/types/store";
 import { useQuery } from "@tanstack/react-query";
 
 type Params = {
@@ -20,7 +20,7 @@ type ApiStoreSummary = {
   storeId: number;
   name: string;
   address: string;
-  category: RestaurantSummary["category"];
+  category: Category;
   rating: number | null;
   reviewCount: number | null;
   distance?: number | null;
@@ -28,8 +28,8 @@ type ApiStoreSummary = {
   isOpenNow?: boolean | null;
   latitude?: number | string | null;
   longitude?: number | string | null;
-  lat: number;
-  lng: number;
+  lat?: number | string | null;
+  lng?: number | string | null;
 };
 
 type ApiResponse = {
@@ -64,9 +64,9 @@ function toSummary(s: ApiStoreSummary): RestaurantSummary {
     rating: typeof s.rating === "number" ? s.rating : 0,
     reviewCount: typeof s.reviewCount === "number" ? s.reviewCount : 0,
     distanceKm: typeof s.distance === "number" ? s.distance : undefined,
-    thumbnailUrl: (s.mainImageUrl ?? undefined) || undefined,
+    thumbnailUrl: s.mainImageUrl ?? undefined,
     isOpenNow: s.isOpenNow ?? undefined,
-    location: { lat: lat ?? NaN, lng: lng ?? NaN },
+    ...(lat != null && lng != null ? { location: { lat, lng } } : {}),
   };
 }
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -92,14 +92,6 @@ export default function SearchPage() {
 
     return new Promise((resolve) => {
       geocoder.addressSearch(address, (res: any[], status: string) => {
-        console.log(
-          "[geocode] status:",
-          status,
-          "addresS:",
-          address,
-          "res:",
-          res,
-        );
         if (status !== kakao.maps.services.Status.OK || !res?.[0]) {
           resolve(null);
           return;
@@ -205,10 +197,6 @@ export default function SearchPage() {
         return;
       }
       const targets = results.filter((r) => !isValidLatLng(r.location));
-      console.log(
-        "[geocode targets]",
-        targets.map((t) => ({ id: t.id, name: t.name, address: t.address })),
-      );
       if (targets.length === 0) return;
       const next = new Map(geoMap);
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -92,6 +92,14 @@ export default function SearchPage() {
 
     return new Promise((resolve) => {
       geocoder.addressSearch(address, (res: any[], status: string) => {
+        console.log(
+          "[geocode] status:",
+          status,
+          "addresS:",
+          address,
+          "res:",
+          res,
+        );
         if (status !== kakao.maps.services.Status.OK || !res?.[0]) {
           resolve(null);
           return;
@@ -102,6 +110,7 @@ export default function SearchPage() {
           resolve(null);
           return;
         }
+
         resolve({ lat, lng });
       });
     });
@@ -196,6 +205,10 @@ export default function SearchPage() {
         return;
       }
       const targets = results.filter((r) => !isValidLatLng(r.location));
+      console.log(
+        "[geocode targets]",
+        targets.map((t) => ({ id: t.id, name: t.name, address: t.address })),
+      );
       if (targets.length === 0) return;
       const next = new Map(geoMap);
 

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -24,7 +24,7 @@ export type RestaurantSummary = {
   distanceKm?: number;
   thumbnailUrl?: string;
   isOpenNow?: boolean;
-  location: Location;
+  location?: Location;
 };
 
 export type BusinessHour = {
@@ -69,7 +69,7 @@ export const categoryLabel: Record<Category, string> = {
 export type DepositRate = "TEN" | "TWENTY" | "THIRTY" | "FORTY" | "FIFTY";
 
 export type BusinessNumberDto = {
-  name:string;
+  name: string;
   businessNumber: string;
   startDate: string;
 };


### PR DESCRIPTION
## 💡 개요
가게 검색 시, api에서 내려주는 좌표를 우선 사용하도록 수정하고, 기존에 주소 기반으로 진행한 지오코딩은 fallback으로 유지하도록 개선함

## 🔢 관련 이슈 링크
- Closes #107 

## 💻 작업내용
- 검색 api 응답의` latitude/longitude`를 `RestaurantSummary.location`으로 매핑
- 좌표가 있으면 api 좌표를 우선사용하도록 수정
- 좌표 없거나 유효하지 않은 주소인 경우는 기존 카카오 주소 지오코딩을 fallback으로 유지
- `RestaurantSummary.location`을 optional로 변경해서 좌표가 없을때의 케이스 대응함.

## 📌 변경사항PR
- [ ] FEAT: 새로운 기능 추가
- [x] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [ ] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
- N/A

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 매장 위치 필드와 좌표 입력을 더 유연하게 처리하도록 구조 개선(문자열/숫자 형태 좌표 호환, 위경도 별칭 지원)
  * 거리 및 대표 이미지 필드명 표준화(거리 → distance, 이미지 → mainImageUrl)
  * 매장 위치 정보가 없을 경우 선택적으로 처리하도록 변경(위치 필드 옵셔널화)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->