### PR TITLE
design: 예약 모달 UX 개선

### DIFF
--- a/src/components/reservation/modals/PaymentModal.tsx
+++ b/src/components/reservation/modals/PaymentModal.tsx
@@ -13,6 +13,9 @@ import { requestPayment } from "@/api/endpoints/payments";
 import { loadTossPayments } from "@tosspayments/tosspayments-sdk";
 import { useNavigate } from "react-router-dom";
 import { useUserId } from "@/stores/useAuthStore";
+import { useModalPresence } from "@/hooks/common/useModalPresence";
+import { cn } from "@/lib/utils";
+import { backdropMotionClass, panelMotionClass } from "@/utils/modalMotion";
 
 type Props = {
   open: boolean;
@@ -179,7 +182,9 @@ export default function PaymentModal({
     onBack();
     onOpenChange(false);
   };
-  if (!open) return null;
+
+  const { rendered, entered } = useModalPresence(open, 220);
+  if (!rendered) return null;
   if (!restaurant || !draft) return null;
   if (!booking) return null;
 
@@ -192,11 +197,16 @@ export default function PaymentModal({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/50"
+        className={cn(backdropMotionClass(entered), "z-0")}
         aria-label="모달 닫기"
         onClick={handleRequestClose}
       />
-      <div className="relative z-10 w-[92vw] max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-xl overflow-hidden">
+      <div
+        className={cn(
+          panelMotionClass(entered),
+          "relative z-10 w-[92vw] max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-xl overflow-hidden",
+        )}
+      >
         <div className="flex items-center justify-between px-5 py-4 border-b">
           <h3 className="text-lg">예약금 결제</h3>
           <button

--- a/src/components/reservation/modals/ReservationCompleteModal.tsx
+++ b/src/components/reservation/modals/ReservationCompleteModal.tsx
@@ -1,6 +1,9 @@
+import { useModalPresence } from "@/hooks/common/useModalPresence";
+import { cn } from "@/lib/utils";
 import type { ReservationDraft } from "@/types/restaurant";
 import type { RestaurantDetail } from "@/types/store";
 import { toYmd } from "@/utils/date";
+import { backdropMotionClass, panelMotionClass } from "@/utils/modalMotion";
 import { toHHmm } from "@/utils/time";
 import { CircleCheck } from "lucide-react";
 import { useEffect } from "react";
@@ -28,7 +31,7 @@ export default function ReservationCompleteModal({
 
     return () => window.clearTimeout(t);
   }, [open, autoCloseMs, onClose]);
-
+  const { rendered, entered } = useModalPresence(open, 220);
   if (!open) return null;
 
   const { people, date, time } = draft;
@@ -44,11 +47,16 @@ export default function ReservationCompleteModal({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/50"
+        className={cn(backdropMotionClass(entered), "z-0")}
         aria-label="모달 닫기"
         onClick={onClose}
       />
-      <div className="relative z-10 w-[92vw] max-w-md rounded-2xl bg-white shadow-xl overflow-hidden">
+      <div
+        className={cn(
+          panelMotionClass(entered),
+          "relative z-10 w-[92vw] max-w-md rounded-2xl bg-white shadow-xl overflow-hidden",
+        )}
+      >
         <div className="flex flex-col items-center justify-between p-8 space-y-4">
           <CircleCheck className="h-25 w-25 text-green-400" />
           <p className="text-2xl mt-2">예약이 완료되었습니다!</p>

--- a/src/components/reservation/modals/ReservationCompleteModal.tsx
+++ b/src/components/reservation/modals/ReservationCompleteModal.tsx
@@ -32,7 +32,7 @@ export default function ReservationCompleteModal({
     return () => window.clearTimeout(t);
   }, [open, autoCloseMs, onClose]);
   const { rendered, entered } = useModalPresence(open, 220);
-  if (!open) return null;
+  if (!rendered) return null;
 
   const { people, date, time } = draft;
   console.log("[complete] draft=", draft);

--- a/src/components/reservation/modals/ReservationConfirmModal.tsx
+++ b/src/components/reservation/modals/ReservationConfirmModal.tsx
@@ -1,13 +1,16 @@
 import type { CreateBookingResult } from "@/api/endpoints/reservations.ts";
 import { useConfirmClose } from "@/hooks/common/useConfirmClose";
+import { useModalPresence } from "@/hooks/common/useModalPresence";
 import { useCreateBooking } from "@/hooks/reservation/useCreateBooking";
 import { useDepositRate } from "@/hooks/reservation/useDepositRate";
 import { useMenus } from "@/hooks/reservation/useMenus";
+import { cn } from "@/lib/utils";
 import type { ReservationDraft } from "@/types/restaurant";
 import type { RestaurantDetail } from "@/types/store";
 import { toYmd } from "@/utils/date";
 import { toDepositRate } from "@/utils/depositRate";
 import { calcMenuTotal } from "@/utils/menu";
+import { backdropMotionClass, panelMotionClass } from "@/utils/modalMotion";
 import { formatKrw } from "@/utils/money";
 import { calcDeposit } from "@/utils/payment";
 import { tablePrefLabel } from "@/utils/reservation";
@@ -47,8 +50,8 @@ export default function ReservationConfirmModal({
   const depositAmount = calcDeposit(menuTotal, toDepositRate(rate));
 
   const isCalculating = menusQuery.isLoading || depositQuery.isLoading;
-
-  if (!open) return null;
+  const { rendered, entered } = useModalPresence(open, 220);
+  if (!rendered) return null;
 
   const onClickConfirm = async () => {
     if (booking) {
@@ -96,12 +99,17 @@ export default function ReservationConfirmModal({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/50"
+        className={cn(backdropMotionClass(entered), "z-0")}
         aria-label="모달 닫기"
         onClick={handleRequestClose}
       />
 
-      <div className="relative z-10 w-[92vw] max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-xl">
+      <div
+        className={cn(
+          panelMotionClass(entered),
+          "relative z-10 w-[92vw] max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-xl",
+        )}
+      >
         {/* 헤더 */}
         <div className="flex items-center justify-between px-5 py-4 border-b">
           <h3 className="text-lg">예약 내용 확인</h3>

--- a/src/components/reservation/modals/ReservationMenuModal.tsx
+++ b/src/components/reservation/modals/ReservationMenuModal.tsx
@@ -12,6 +12,8 @@ import { calcDeposit } from "@/utils/payment";
 import { useConfirmClose } from "@/hooks/common/useConfirmClose";
 import { toDepositRate } from "@/utils/depositRate";
 import type { RestaurantDetail } from "@/types/store";
+import { useModalPresence } from "@/hooks/common/useModalPresence";
+import { backdropMotionClass, panelMotionClass } from "@/utils/modalMotion";
 
 type Props = {
   open: boolean;
@@ -126,8 +128,8 @@ export default function ReservationMenuModal({
   );
 
   const handleRequestClose = useConfirmClose(onClose);
-
-  if (!open) return null;
+  const { rendered, entered } = useModalPresence(open, 220);
+  if (rendered) return null;
 
   return (
     <div
@@ -138,11 +140,16 @@ export default function ReservationMenuModal({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/50"
+        className={cn(backdropMotionClass(entered), "z-0")}
         aria-label="모달 닫기"
         onClick={handleRequestClose}
       />
-      <div className="flex flex-col relative z-10 w-[92vw] max-w-4xl max-h-[calc(100vh-96px)] overflow-y-auto rounded-2xl bg-white shadow-xl overflow-hidden">
+      <div
+        className={cn(
+          panelMotionClass(entered),
+          "flex flex-col relative z-10 w-[92vw] max-w-4xl max-h-[calc(100vh-96px)] overflow-y-auto rounded-2xl bg-white shadow-xl overflow-hidden",
+        )}
+      >
         <div className="flex items-center justify-between px-6 py-4 border-b">
           <div className="min-w-0">
             <h2 className="text-xl truncate">{restaurant.name} 메뉴선택</h2>

--- a/src/components/reservation/modals/ReservationMenuModal.tsx
+++ b/src/components/reservation/modals/ReservationMenuModal.tsx
@@ -129,7 +129,7 @@ export default function ReservationMenuModal({
 
   const handleRequestClose = useConfirmClose(onClose);
   const { rendered, entered } = useModalPresence(open, 220);
-  if (rendered) return null;
+  if (!rendered) return null;
 
   return (
     <div
@@ -140,7 +140,7 @@ export default function ReservationMenuModal({
     >
       <button
         type="button"
-        className={cn(backdropMotionClass(entered), "z-0")}
+        className={cn(backdropMotionClass(entered))}
         aria-label="모달 닫기"
         onClick={handleRequestClose}
       />

--- a/src/components/reservation/modals/ReservationModal.tsx
+++ b/src/components/reservation/modals/ReservationModal.tsx
@@ -19,6 +19,8 @@ import { useAvailableTimes } from "@/hooks/reservation/useAvailableTimes";
 import { useAvailableTables } from "@/hooks/reservation/useAvailableTables";
 import { seatsTypeToSeatType } from "@/utils/reservation";
 import type { RestaurantDetail } from "@/types/store";
+import { useModalPresence } from "@/hooks/common/useModalPresence";
+import { backdropMotionClass, panelMotionClass } from "@/utils/modalMotion";
 
 type Props = {
   open: boolean;
@@ -67,7 +69,7 @@ export default function ReservationModal({
       : null,
   );
   const { rate: depositRate } = useDepositRate(restaurant.id);
-
+  const { rendered, entered } = useModalPresence(open, 220);
   const didInitRef = useRef(false);
 
   useEffect(() => {
@@ -164,7 +166,7 @@ export default function ReservationModal({
     setSelectedTableId(null);
   }, [people, date, time]);
 
-  if (!open) return null;
+  if (!rendered) return null;
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
@@ -174,12 +176,17 @@ export default function ReservationModal({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/50 z-0"
+        className={cn(backdropMotionClass(entered), "z-0")}
         aria-label="모달 닫기"
         onClick={handleRequestClose}
       />
 
-      <div className="relative z-10 w-[92vw] max-w-4xl rounded-2xl bg-white shadow-xl overflow-hidden max-h-[calc(100vh-96px)] flex flex-col">
+      <div
+        className={cn(
+          "relative z-10 w-[92vw] max-w-4xl rounded-2xl bg-white shadow-xl overflow-hidden max-h-[calc(100vh-96px)] flex flex-col",
+          panelMotionClass(entered),
+        )}
+      >
         <div className="flex items-center justify-between px-6 py-4 border-b shrink-0">
           <div className="min-w-0">
             <h2 className="text-xl truncate font-medium">{restaurant.name} </h2>

--- a/src/components/restaurant/RestaurantDetailModal.tsx
+++ b/src/components/restaurant/RestaurantDetailModal.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "@/stores/useAuthStore";
 import { useModalMotion } from "@/hooks/common/useModalMotion";
 import { backdropMotionClass, panelMotionClass } from "@/utils/modalMotion";
 import { cn } from "@/lib/utils";
+import { useModalPresence } from "@/hooks/common/useModalPresence";
 
 type Props = {
   open: boolean;
@@ -70,7 +71,7 @@ export default function RestaurantDetailModal({
 }: Props) {
   const nav = useNavigate();
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-  const { entered } = useModalMotion(open);
+  const { rendered, entered } = useModalPresence(open);
   const handleReserveClick = () => {
     if (!isAuthenticated) {
       alert("로그인이 필요한 서비스입니다.");
@@ -81,7 +82,7 @@ export default function RestaurantDetailModal({
     onClickReserve();
   };
 
-  if (!open) return null;
+  if (!rendered) return null;
 
   if (status === "idle" || status === "loading") {
     return (

--- a/src/components/restaurant/RestaurantDetailModal.tsx
+++ b/src/components/restaurant/RestaurantDetailModal.tsx
@@ -3,6 +3,9 @@ import { Clock, Star, X } from "lucide-react";
 import { Button } from "../ui/button";
 import { useNavigate } from "react-router-dom";
 import { useAuthStore } from "@/stores/useAuthStore";
+import { useModalMotion } from "@/hooks/common/useModalMotion";
+import { backdropMotionClass, panelMotionClass } from "@/utils/modalMotion";
+import { cn } from "@/lib/utils";
 
 type Props = {
   open: boolean;
@@ -67,7 +70,7 @@ export default function RestaurantDetailModal({
 }: Props) {
   const nav = useNavigate();
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
-
+  const { entered } = useModalMotion(open);
   const handleReserveClick = () => {
     if (!isAuthenticated) {
       alert("로그인이 필요한 서비스입니다.");
@@ -90,11 +93,16 @@ export default function RestaurantDetailModal({
       >
         <button
           type="button"
-          className="absolute inset-0 bg-black/40"
+          className={backdropMotionClass(entered)}
           aria-label="모달 닫기"
           onClick={() => onOpenChange(false)}
         />
-        <div className="relative z-10 w-[92vw] max-w-3xl rounded-2xl bg-white shadow-xl p-6">
+        <div
+          className={cn(
+            "relative z-10 w-[92vw] max-w-3xl rounded-2xl bg-white shadow-xl p-6",
+            panelMotionClass(entered),
+          )}
+        >
           <div className="flex items-center justify-between">
             <p className="text-lg">상세 정보 불러오는 중..</p>
             <button
@@ -184,11 +192,16 @@ export default function RestaurantDetailModal({
     >
       <button
         type="button"
-        className="absolute inset-0 bg-black/40"
+        className={backdropMotionClass(entered)}
         aria-label="모달 닫기"
         onClick={() => onOpenChange(false)}
       />
-      <div className="relative z-10 w-[92vw] max-w-3xl rounded-2xl bg-white shadow-xl overflow-hidden max-h-[calc(100vh-96px)] flex flex-col">
+      <div
+        className={cn(
+          "relative z-10 w-[92vw] max-w-3xl rounded-2xl bg-white shadow-xl overflow-hidden max-h-[calc(100vh-96px)] flex flex-col",
+          panelMotionClass(entered),
+        )}
+      >
         <div className="flex items-center justify-between px-6 py-4 border-b shrink-0">
           <div className="min-w-0">
             <h2 className="text-xl truncate">{restaurant.name}</h2>

--- a/src/components/restaurant/RestaurantDetailModal.tsx
+++ b/src/components/restaurant/RestaurantDetailModal.tsx
@@ -3,7 +3,6 @@ import { Clock, Star, X } from "lucide-react";
 import { Button } from "../ui/button";
 import { useNavigate } from "react-router-dom";
 import { useAuthStore } from "@/stores/useAuthStore";
-import { useModalMotion } from "@/hooks/common/useModalMotion";
 import { backdropMotionClass, panelMotionClass } from "@/utils/modalMotion";
 import { cn } from "@/lib/utils";
 import { useModalPresence } from "@/hooks/common/useModalPresence";

--- a/src/hooks/common/useModalMotion.ts
+++ b/src/hooks/common/useModalMotion.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+export function useModalMotion(open: boolean) {
+  const [entered, setEntered] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setEntered(false);
+      return;
+    }
+    const id = requestAnimationFrame(() => setEntered(true));
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+  return { entered };
+}

--- a/src/hooks/common/useModalPresence.ts
+++ b/src/hooks/common/useModalPresence.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from "react";
+
+export function useModalPresence(open: boolean, durationMs = 220) {
+  const [rendered, setRendered] = useState(open);
+  const [entered, setEntered] = useState(false);
+  const timeRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      if (timeRef.current) {
+        window.clearTimeout(timeRef.current);
+        timeRef.current = null;
+      }
+      setRendered(true);
+      const raf = requestAnimationFrame(() => setEntered(true));
+      return () => cancelAnimationFrame(raf);
+    }
+    setEntered(false);
+
+    timeRef.current = window.setTimeout(() => {
+      setRendered(false);
+      timeRef.current = null;
+    }, durationMs);
+
+    return () => {
+      if (timeRef.current) {
+        window.clearTimeout(timeRef.current);
+        timeRef.current = null;
+      }
+    };
+  }, [open, durationMs]);
+
+  return { rendered, entered };
+}

--- a/src/utils/modalMotion.ts
+++ b/src/utils/modalMotion.ts
@@ -1,0 +1,15 @@
+export function backdropMotionClass(entered: boolean) {
+  return [
+    "absolute inset-0 bg-black/50",
+    "transition-opacity duration-200 ease-out",
+    entered ? "opacity-100" : "opacity-0",
+  ].join(" ");
+}
+
+export function panelMotionClass(entered: boolean) {
+  return [
+    "transition-all duration-200 ease-out",
+    "will-change-transform will-change-opacity",
+    entered ? "opacity-100 scale-100" : "opacity-0 scale-[0.96]",
+  ].join(" ");
+}


### PR DESCRIPTION
## 💡 개요
예약 flow 모달들 열리고 닫힐때 애니메이션 추가해서 UX개선
## 🔢 관련 이슈 링크
- Closes #100 

## 💻 작업내용
- 공통 모달 애니메이션 훅(useModalPresence)추가
- backdrop, panel  유틸 추가
- 예약 관련 모달에 적용
- 닫힘 시에도 자연스럽게 사라지도록 언마운트 지연 처리

## 📌 변경사항PR
- [ ] FEAT: 새로운 기능 추가
- [ ] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [ ] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [x] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
- N/A

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 모든 예약 및 음식점 관련 모달 창에 부드러운 입장/퇴장 애니메이션 추가
  * 모달 백드롭과 패널의 투명도 및 크기 변환 효과로 더욱 자연스러운 시각적 전환 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->