### PR TITLE
feat: 가게 설정 테이블 이미지 삭제 UI 처리 및 삭제 확인 모달 추가

### DIFF
--- a/src/api/owner/stores.ts
+++ b/src/api/owner/stores.ts
@@ -66,6 +66,11 @@ export interface TableImagesResponse {
   tableImageUrls: string[];
 }
 
+// export interface TableImagesResponse {
+//   storeId: number;
+//   tableImages: TableImage[];
+// }
+
 export function getStore(storeId: number | string) {
   return api.get<ApiResponse<StoreDetail>>(`/api/v1/stores/${storeId}`);
 }
@@ -107,6 +112,18 @@ export const getTableImages = async (
 
   return res.data.result.tableImageUrls ?? [];
 };
+
+// export const getTableImages = async (
+//   storeId: number | string,
+// ): Promise<TableImage[]> => {
+//   const res = await api.get<ApiResponse<TableImagesResponse>>(
+//     `/api/v1/stores/${storeId}/table-images`,
+//   );
+
+//   if (!res.data.isSuccess) throw new Error(res.data.message);
+
+//   return res.data.result.tableImages ?? [];
+// };
 
 export const uploadTableImages = async (
   storeId: number | string,

--- a/src/api/owner/stores.ts
+++ b/src/api/owner/stores.ts
@@ -104,7 +104,7 @@ export const getTableImages = async (
 
   if (!res.data.isSuccess) throw new Error(res.data.message);
 
-  return res.data.result.tableImages ?? [];
+  return res.data.result?.tableImages ?? [];
 };
 
 export const uploadTableImages = async (

--- a/src/api/owner/stores.ts
+++ b/src/api/owner/stores.ts
@@ -11,7 +11,6 @@ export interface StoreDetail {
   isApproved: boolean;
   rating?: number;
   reviewCount?: number;
-  tableImageUrls?: string[];
 }
 
 export interface BusinessHour {
@@ -57,19 +56,14 @@ interface MyStoreResponse {
 }
 
 export interface TableImage {
-  tableId: number;
+  tableImageId: number;
   tableImageUrl: string;
 }
 
 export interface TableImagesResponse {
   storeId: number;
-  tableImageUrls: string[];
+  tableImages: TableImage[];
 }
-
-// export interface TableImagesResponse {
-//   storeId: number;
-//   tableImages: TableImage[];
-// }
 
 export function getStore(storeId: number | string) {
   return api.get<ApiResponse<StoreDetail>>(`/api/v1/stores/${storeId}`);
@@ -103,27 +97,15 @@ export const getMyStores = async (): Promise<MyStore[]> => {
 
 export const getTableImages = async (
   storeId: number | string,
-): Promise<string[]> => {
+): Promise<TableImage[]> => {
   const res = await api.get<ApiResponse<TableImagesResponse>>(
     `/api/v1/stores/${storeId}/table-images`,
   );
 
   if (!res.data.isSuccess) throw new Error(res.data.message);
 
-  return res.data.result.tableImageUrls ?? [];
+  return res.data.result.tableImages ?? [];
 };
-
-// export const getTableImages = async (
-//   storeId: number | string,
-// ): Promise<TableImage[]> => {
-//   const res = await api.get<ApiResponse<TableImagesResponse>>(
-//     `/api/v1/stores/${storeId}/table-images`,
-//   );
-
-//   if (!res.data.isSuccess) throw new Error(res.data.message);
-
-//   return res.data.result.tableImages ?? [];
-// };
 
 export const uploadTableImages = async (
   storeId: number | string,
@@ -152,12 +134,12 @@ export const uploadTableImages = async (
 
 export const deleteTableImages = async (
   storeId: number | string,
-  tableIds: number[],
-): Promise<ApiResponse<{ tableId: number }>> => {
-  const response = await api.delete<ApiResponse<{ tableId: number }>>(
+  tableImageIds: number[],
+): Promise<ApiResponse<{ tableImageId: number }>> => {
+  const response = await api.delete<ApiResponse<{ tableImageId: number }>>(
     `/api/v1/stores/${storeId}/table-images`,
     {
-      data: tableIds,
+      data: tableImageIds,
     },
   );
   const data = response.data;

--- a/src/api/owner/stores.ts
+++ b/src/api/owner/stores.ts
@@ -11,7 +11,7 @@ export interface StoreDetail {
   isApproved: boolean;
   rating?: number;
   reviewCount?: number;
-  tableImages?: TableImage[];
+  tableImageUrls?: string[];
 }
 
 export interface BusinessHour {
@@ -98,18 +98,14 @@ export const getMyStores = async (): Promise<MyStore[]> => {
 
 export const getTableImages = async (
   storeId: number | string,
-): Promise<TableImage[]> => {
-  const res = await api.get<
-    ApiResponse<{ storeId: number; tableImageUrls: string[] }>
-  >(`/api/v1/stores/${storeId}/table-images`);
+): Promise<string[]> => {
+  const res = await api.get<ApiResponse<TableImagesResponse>>(
+    `/api/v1/stores/${storeId}/table-images`,
+  );
 
   if (!res.data.isSuccess) throw new Error(res.data.message);
 
-  // ⚠️ API 응답에 tableId가 포함되지 않아 삭제용 ID로 사용할 수 없음
-  return res.data.result.tableImageUrls.map((url) => ({
-    tableId: -1, // placeholder — 삭제 기능에 사용 금지
-    tableImageUrl: url,
-  }));
+  return res.data.result.tableImageUrls ?? [];
 };
 
 export const uploadTableImages = async (

--- a/src/components/owner/StoreSettings.tsx
+++ b/src/components/owner/StoreSettings.tsx
@@ -421,6 +421,7 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
                 />
                 <button
                   type="button"
+                  aria-label={`새 이미지 ${index + 1} 삭제`}
                   onClick={() => handleDeleteImage(index)}
                   className="absolute top-2 right-2 bg-red-500 text-white text-xs px-2 py-1 rounded hover:bg-red-400 cursor-pointer transition"
                 >

--- a/src/components/owner/StoreSettings.tsx
+++ b/src/components/owner/StoreSettings.tsx
@@ -85,6 +85,7 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
         setNewFiles([]);
       } catch (e) {
         alert("가게 정보를 불러오는데 실패했습니다.");
+        return;
       }
     })();
   }, [storeId]);
@@ -116,9 +117,9 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
     e.target.value = "";
   };
 
-  // const handleDeleteImage = (fileIndex: number) => {
-  //   setNewFiles((prev) => prev.filter((_, i) => i !== fileIndex));
-  // };
+  const handleDeleteImage = (fileIndex: number) => {
+    setNewFiles((prev) => prev.filter((_, i) => i !== fileIndex));
+  };
 
   const inputStyle =
     "w-full border border-gray-200 rounded-lg p-4 mt-2 text-sm text-black focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition-all placeholder:text-gray-400";
@@ -388,6 +389,7 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
                 />
                 <button
                   type="button"
+                  aria-label={`테이블 이미지 ${idx + 1} 삭제`}
                   onClick={() => {
                     const ok = window.confirm(
                       "정말로 이 사진을 삭제하시겠습니까?\n(설정 저장을 눌러야 최종 반영됩니다)",
@@ -417,13 +419,13 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
                   className="w-full h-32 object-cover rounded-lg"
                   onLoad={() => URL.revokeObjectURL(previewUrl)}
                 />
-                {/* <button
+                <button
                   type="button"
-                  onClick={() => handleDeleteImage(undefined, index)}
-                  className="cursor-pointer absolute top-1 right-1 bg-gray-500 text-white text-xs px-2 py-1 rounded-lg hover:bg-gray-800 transition-colors"
+                  onClick={() => handleDeleteImage(index)}
+                  className="absolute top-2 right-2 bg-red-500 text-white text-xs px-2 py-1 rounded hover:bg-red-400 cursor-pointer transition"
                 >
-                  <X className="size-4" />
-                </button> */}
+                  삭제
+                </button>
               </div>
             );
           })}

--- a/src/components/owner/StoreSettings.tsx
+++ b/src/components/owner/StoreSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Mail, Phone, MapPin, Clock, ChevronDown, X } from "lucide-react";
+import { Mail, Phone, MapPin, Clock, ChevronDown } from "lucide-react";
 import {
   getStore,
   updateStore,
@@ -116,9 +116,9 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
     e.target.value = "";
   };
 
-  const handleDeleteImage = (fileIndex: number) => {
-    setNewFiles((prev) => prev.filter((_, i) => i !== fileIndex));
-  };
+  // const handleDeleteImage = (fileIndex: number) => {
+  //   setNewFiles((prev) => prev.filter((_, i) => i !== fileIndex));
+  // };
 
   const inputStyle =
     "w-full border border-gray-200 rounded-lg p-4 mt-2 text-sm text-black focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition-all placeholder:text-gray-400";

--- a/src/components/owner/StoreSettings.tsx
+++ b/src/components/owner/StoreSettings.tsx
@@ -54,6 +54,10 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
 
   const [deletedUrls, setDeletedUrls] = useState<Set<string>>(new Set());
 
+  // const [tableImages, setTableImages] = useState<TableImage[]>([]);
+  // const [deletedIds, setDeletedIds] = useState<Set<number>>(new Set());
+  // const [newFiles, setNewFiles] = useState<File[]>([]);
+
   useEffect(() => {
     if (!storeId) return;
 
@@ -85,6 +89,40 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
       }
     })();
   }, [storeId]);
+
+  // useEffect(() => {
+  //   if (!storeId) return;
+
+  //   (async () => {
+  //     try {
+  //       const res = await getStore(storeId);
+  //       const store = res.data.result;
+
+  //       setStoreName(store.storeName);
+  //       setDescription(store.description ?? "");
+  //       setPhone(store.phone ?? "");
+  //       setAddress(store.address ?? "");
+  //       if (store.businessHours?.length) {
+  //         const open = store.businessHours.find((b) => !b.isClosed);
+  //         if (open?.openTime && open?.closeTime) {
+  //           setOpenTime(open.openTime);
+  //           setCloseTime(open.closeTime);
+  //         }
+  //         const closed = store.businessHours
+  //           .filter((b) => b.isClosed)
+  //           .map((b) => dayMapFromApi[b.day]);
+  //         setClosedDays(closed);
+  //       }
+
+  //       const imgs = await getTableImages(storeId);
+  //       setTableImages(imgs);
+  //       setDeletedIds(new Set());
+  //       setNewFiles([]);
+  //     } catch (e) {
+  //       alert("가게 정보를 불러오는데 실패했습니다.");
+  //     }
+  //   })();
+  // }, [storeId]);
 
   const toggleDay = (day: string) => {
     setClosedDays((prev) =>
@@ -404,6 +442,36 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
                 </button>
               </div>
             ))}
+          {/* 
+          {tableImages
+            .filter((img) => !deletedIds.has(img.tableId))
+            .map((img, idx) => (
+              <div key={img.tableId} className="relative">
+                <img
+                  src={img.tableImageUrl}
+                  alt={`테이블 이미지 ${idx + 1}`}
+                  className="w-full h-32 object-cover rounded-lg"
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    const ok = window.confirm(
+                      "정말로 이 사진을 삭제하시겠습니까?\n(설정 저장을 눌러야 최종 반영됩니다)",
+                    );
+                    if (!ok) return;
+
+                    setDeletedIds((prev) => {
+                      const next = new Set(prev);
+                      next.add(img.tableId);
+                      return next;
+                    });
+                  }}
+                  className="absolute top-2 right-2 bg-red-500 text-white text-xs px-2 py-1 rounded hover:bg-red-400 cursor-pointer transition"
+                >
+                  삭제
+                </button>
+              </div>
+            ))} */}
 
           {newFiles.map((file, index) => {
             const previewUrl = URL.createObjectURL(file);
@@ -466,6 +534,13 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
               );
               return;
             }
+
+            if (deletedUrls.size > 0) {
+              alert(
+                "현재 API 스펙에서는 기존 이미지 삭제를 서버에 반영할 수 없습니다.",
+              );
+              // await deleteTableImages(storeId, Array.from(deletedIds));
+            }
             if (newFiles.length > 0) {
               try {
                 await uploadTableImages(storeId, newFiles);
@@ -473,17 +548,19 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
                 alert("이미지 업로드에 실패했습니다.");
                 return;
               }
-            }
-            if (deletedUrls.size > 0) {
-              alert(
-                "현재 API 스펙에서는 기존 이미지 삭제를 서버에 반영할 수 없습니다.",
-              );
+              // await uploadTableImages(storeId, newFiles);
             }
             const urls = await getTableImages(storeId);
             setTableImageUrls(urls);
             setNewFiles([]);
             setDeletedUrls(new Set());
             alert("설정이 저장되었습니다.");
+
+            // const imgs = await getTableImages(storeId);
+            // setTableImages(imgs);
+            // setDeletedIds(new Set());
+            // setNewFiles([]);
+            // alert("설정이 저장되었습니다.");
           }}
           className="cursor-pointer bg-blue-600 text-white px-12 py-4 rounded-xl shadow-lg hover:bg-blue-700 active:scale-95 transition-all text-lg"
         >

--- a/src/components/owner/StoreSettings.tsx
+++ b/src/components/owner/StoreSettings.tsx
@@ -4,9 +4,8 @@ import {
   getStore,
   updateStore,
   updateBusinessHours,
-  type TableImage,
-  deleteTableImages,
   uploadTableImages,
+  getTableImages,
 } from "@/api/owner/stores";
 
 interface StoreSettingsProps {
@@ -36,13 +35,11 @@ const dayMapToApi: Record<string, any> = {
 };
 
 const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
-  const [storeName, setStoreName] = useState("맛있는 레스토랑");
-  const [description, setDescription] = useState(
-    "신선한 재료로 만드는 정성 가득한 음식을 제공합니다.",
-  );
-  const [phone, setPhone] = useState("02-1234-5678");
-  const [email, setEmail] = useState("store@example.com");
-  const [address, setAddress] = useState("서울특별시 강남구 테헤란로 123");
+  const [storeName, setStoreName] = useState("");
+  const [description, setDescription] = useState("");
+  const [phone, setPhone] = useState("");
+  const [email, setEmail] = useState("");
+  const [address, setAddress] = useState("");
 
   const [openTime, setOpenTime] = useState("11:00");
   const [closeTime, setCloseTime] = useState("22:00");
@@ -52,16 +49,20 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
   const [minGuests, setMinGuests] = useState<number | string>(1);
   const [maxGuests, setMaxGuests] = useState<number | string>(20);
 
-  const [tableImages, setTableImages] = useState<TableImage[]>([]);
+  const [tableImageUrls, setTableImageUrls] = useState<string[]>([]);
   const [newFiles, setNewFiles] = useState<File[]>([]);
-  const [deletedIds, setDeletedIds] = useState<number[]>([]);
+
+  const [deletedUrls, setDeletedUrls] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (!storeId) return;
 
-    getStore(storeId)
-      .then((res) => {
+    (async () => {
+      try {
+        const res = await getStore(storeId);
         const store = res.data.result;
+        setTableImageUrls(store.tableImageUrls ?? []);
+        setDeletedUrls(new Set());
 
         setStoreName(store.storeName);
         setDescription(store.description ?? "");
@@ -74,20 +75,15 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
             setOpenTime(open.openTime);
             setCloseTime(open.closeTime);
           }
-
           const closed = store.businessHours
             .filter((b) => b.isClosed)
             .map((b) => dayMapFromApi[b.day]);
-
           setClosedDays(closed);
         }
-        if (store.tableImages) {
-          setTableImages(store.tableImages);
-        }
-      })
-      .catch(() => {
-        alert("가게 정보를 불러오는 데 실패했습니다.");
-      });
+      } catch (e) {
+        alert("가게 정보를 불러오는데 실패했습니다.");
+      }
+    })();
   }, [storeId]);
 
   const toggleDay = (day: string) => {
@@ -117,19 +113,14 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
     e.target.value = "";
   };
 
-  const handleDeleteImage = (tableId?: number, fileIndex?: number) => {
-    if (tableId !== undefined) {
-      setTableImages((prev) => prev.filter((img) => img.tableId !== tableId));
-      setDeletedIds((prev) => [...prev, tableId]);
-    }
-
+  const handleDeleteImage = (_tableId?: number, fileIndex?: number) => {
     if (fileIndex !== undefined) {
       setNewFiles((prev) => prev.filter((_, i) => i !== fileIndex));
     }
   };
 
   const inputStyle =
-    "w-full border border-gray-200 rounded-lg p-4 mt-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition-all placeholder:text-gray-400";
+    "w-full border border-gray-200 rounded-lg p-4 mt-2 text-sm text-black focus:ring-2 focus:ring-blue-500 focus:border-transparent outline-none transition-all placeholder:text-gray-400";
   const labelStyle = "block text-md text-gray-700";
   const sectionStyle = "bg-white border border-gray-200 rounded-lg p-8 mb-6";
 
@@ -140,7 +131,7 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
   return (
     <div className="max-w-7xl mx-auto px-8 py-10">
       <section className={sectionStyle}>
-        <h3 className="text-lg mb-8">기본 정보</h3>
+        <h3 className="text-lg mb-8 text-black font-medium">기본 정보</h3>
         <div className="space-y-6">
           <div>
             <label htmlFor="store-name" className={labelStyle}>
@@ -226,7 +217,7 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
       </section>
 
       <section className={sectionStyle}>
-        <h3 className="text-lg mb-8">영업 시간</h3>
+        <h3 className="text-lg mb-8 text-black font-medium">영업 시간</h3>
         <div className="space-y-6 mb-8">
           <div>
             <label className={labelStyle}>오픈 시간</label>
@@ -282,7 +273,7 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
       </section>
 
       <section className={sectionStyle}>
-        <h3 className="text-lg mb-8">예약 정책</h3>
+        <h3 className="text-lg mb-8 text-black font-medium">예약 정책</h3>
         <div className="space-y-8">
           <div>
             <label className={labelStyle}>예약 가능 기간</label>
@@ -290,7 +281,7 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
               <select
                 value={reservationPeriod}
                 onChange={(e) => setReservationPeriod(e.target.value)}
-                className="cursor-pointer w-full border border-gray-200 rounded-lg p-4 text-sm appearance-none outline-none focus:ring-2 focus:ring-blue-500"
+                className="cursor-pointer w-full border border-gray-200 rounded-lg p-4 appearance-none outline-none focus:ring-2 focus:ring-blue-500"
               >
                 <option>당일만</option>
                 <option>1주일 전까지</option>
@@ -356,45 +347,63 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
       </section>
 
       <section className={sectionStyle}>
-        <h3 className="text-lg mb-8">식당 테이블 이미지</h3>
-
-        <div className="mb-6">
-          <input
-            id="file-upload"
-            type="file"
-            multiple
-            accept="image/*"
-            onChange={handleFileChange}
-            className="hidden"
-          />
-          <div className="mb-7">
-            <p>• 최대 용량: 1MB</p>
-            <p>• 형식: JPG(JPEG), PNG</p>
+        <div className="flex items-center justify-between gap-4 mb-6">
+          <div>
+            <h3 className="text-lg text-black font-medium">
+              식당 테이블 이미지
+            </h3>
+            <p className="mt-2 text-sm text-gray-600">
+              • 최대 용량: 1MB • 형식: JPG(JPEG), PNG
+            </p>
           </div>
-          <label
-            htmlFor="file-upload"
-            className="cursor-pointer rounded-xl text-gray-700 border shadow-sm px-4 py-2  hover:bg-blue-100 hover:text-blue-600 transition-colors inline-block"
-          >
-            이미지 추가하기
-          </label>
+
+          <div className="shrink-0">
+            <input
+              id="file-upload"
+              type="file"
+              multiple
+              accept="image/jpeg,image/jpg,image/png"
+              onChange={handleFileChange}
+              className="hidden"
+            />
+            <label
+              htmlFor="file-upload"
+              className="cursor-pointer rounded-lg shadow-sm text-black border px-4 py-2  hover:bg-blue-100 hover:text-blue-600 hover:font-medium transition-colors inline-block"
+            >
+              이미지 추가하기
+            </label>
+          </div>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          {tableImages.map((img) => (
-            <div key={img.tableId} className="relative">
-              <img
-                src={img.tableImageUrl}
-                alt={`테이블 이미지 ${img.tableId + 1}`}
-                className="w-full h-32 object-cover rounded-lg"
-              />
-              <button
-                onClick={() => handleDeleteImage(img.tableId)}
-                className="absolute top-1 right-1 bg-black text-white text-xs px-2 py-1 rounded"
-              >
-                삭제
-              </button>
-            </div>
-          ))}
+          {tableImageUrls
+            .filter((url) => !deletedUrls.has(url))
+            .map((url, idx) => (
+              <div key={`${url}-${idx}`} className="relative">
+                <img
+                  src={url}
+                  alt={`테이블 이미지 ${idx + 1}`}
+                  className="w-full h-32 object-cover rounded-lg"
+                />
+                <button
+                  onClick={() => {
+                    const ok = window.confirm(
+                      "정말로 이 사진을 삭제하시겠습니까?\n(설정 저장을 눌러야 최종 반영됩니다)",
+                    );
+                    if (!ok) return;
+                    // 현재 가게 관리 화면에서만 안보이게 처리
+                    setDeletedUrls((prev) => {
+                      const next = new Set(prev);
+                      next.add(url);
+                      return next;
+                    });
+                  }}
+                  className="absolute top-2 right-2 bg-red-500 text-white text-xs px-2 py-1 rounded hover:bg-red-400 cursor-pointer transition"
+                >
+                  삭제
+                </button>
+              </div>
+            ))}
 
           {newFiles.map((file, index) => {
             const previewUrl = URL.createObjectURL(file);
@@ -457,33 +466,23 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
               );
               return;
             }
-            try {
-              if (deletedIds.length > 0) {
-                await deleteTableImages(storeId, deletedIds);
-              }
-            } catch (e) {
-              alert("일부 이미지 삭제에 실패했습니다.");
-              return;
-            }
             if (newFiles.length > 0) {
-              for (const file of newFiles) {
-                try {
-                  await uploadTableImages(storeId, [file]);
-                } catch (e) {
-                  console.error(`${file.name} 업로드 실패`);
-                }
+              try {
+                await uploadTableImages(storeId, newFiles);
+              } catch (e) {
+                alert("이미지 업로드에 실패했습니다.");
+                return;
               }
             }
+            if (deletedUrls.size > 0) {
+              alert(
+                "현재 API 스펙에서는 기존 이미지 삭제를 서버에 반영할 수 없습니다.",
+              );
+            }
+            const urls = await getTableImages(storeId);
+            setTableImageUrls(urls);
             setNewFiles([]);
-            setDeletedIds([]);
-            try {
-              const res = await getStore(storeId);
-              if (res.data.result.tableImages) {
-                setTableImages(res.data.result.tableImages);
-              }
-            } catch (e) {
-              console.error("저장 후 데이터 갱신 실패", e);
-            }
+            setDeletedUrls(new Set());
             alert("설정이 저장되었습니다.");
           }}
           className="cursor-pointer bg-blue-600 text-white px-12 py-4 rounded-xl shadow-lg hover:bg-blue-700 active:scale-95 transition-all text-lg"

--- a/src/components/reservation/modals/ReservationModal.tsx
+++ b/src/components/reservation/modals/ReservationModal.tsx
@@ -148,7 +148,8 @@ export default function ReservationModal({
       return { msg: "날짜를 먼저 선택해주세요", times: [] as string[] };
     if (timesQuery.isLoading)
       return { msg: "예약 가능시간 기다리는중..", times: [] };
-    if (timesQuery.isError) return { msg: "서버 조회 실패", times: [] };
+    if (timesQuery.isError)
+      return { msg: "휴무일 입니다. 다른 날짜를 선택해주세요", times: [] };
     if (times.length === 0)
       return { msg: "예약 가능한 시간이 없어요", times: [] };
     return { msg: null as string | null, times };


### PR DESCRIPTION
## 💡 개요
가게 설정 테이블 이미지 삭제 UI 처리 및 삭제 확인 모달 추가

## 🔢 관련 이슈 링크
- Closes #112 

## 💻 작업내용
- 테이블 이미지 삭제 버튼에 confirm 안전장치 추가
- 삭제시 서버 반영 대신 UI에서만 삭제 예약 처리
- 설정 저장 후 이미지 재조회 로직 추가
- 타입 정리 및 불필요한 tableId 관련 로직 제거

## 📌 변경사항PR
- [x] FEAT: 새로운 기능 추가
- [ ] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [ ] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
- 지금 서버에서 조회할떄 tableId가 없어서 delete 요청을 보낼수가 없습니다. 현재 백엔드에 조회시 tableId 내려주는걸로 요청해놓은 상태라서 백엔드 서버 수정되고 배포되면 프론트에서도 바로 서버 반영되도록 수정작업 진행하겠습니다!
- 일단은 UI에서만 삭제 처리되도록하고 실제 서버상 삭제는 안되는 상태입니다!

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 이미지 관리 흐름 강화: 삭제는 클라이언트에서 임시 표시 후 저장 시 일괄 서버 반영(삭제·업로드).
  * 새 파일 미리보기 유지, 삭제 확인 대화상자 추가, 저장 후 목록 자동 갱신 및 오류 알림 개선.
  * 업로드 입력·레이블·스타일 및 섹션 타이포그래피 개선; 이미지 업로드 검증 강화(JPEG/PNG 제한 등).

* **버그 수정**
  * 예약 가능 시간 조회 오류 메시지를 휴무일 안내("휴무일 입니다. 다른 날짜를 선택해주세요")로 명확화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->