### PR TITLE
fix: 브레이크타임 모달 수정 및 가게 설정 주소 입력 수정

### DIFF
--- a/src/components/owner/BreakTimeModal.tsx
+++ b/src/components/owner/BreakTimeModal.tsx
@@ -73,11 +73,6 @@ const BreakTimeModal: React.FC<Props> = ({
             />
           </div>
 
-          <div className="bg-gray-50 rounded-lg p-3 text-sm text-gray-600">
-            영업 시간: {openTime} ~ {closeTime}
-            <br />
-            설정할 브레이크 타임: {start} ~ {end}
-          </div>
         </div>
 
         <div className="flex gap-3 mt-6">

--- a/src/components/owner/StoreSettings.tsx
+++ b/src/components/owner/StoreSettings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Mail, Phone, MapPin, Clock, ChevronDown } from "lucide-react";
+import { Phone, MapPin, Clock, ChevronDown } from "lucide-react";
 import {
   getStore,
   updateStore,
@@ -40,7 +40,6 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
   const [storeName, setStoreName] = useState("");
   const [description, setDescription] = useState("");
   const [phone, setPhone] = useState("");
-  const [email, setEmail] = useState("");
   const [address, setAddress] = useState("");
 
   const [openTime, setOpenTime] = useState("11:00");

--- a/src/components/owner/StoreSettings.tsx
+++ b/src/components/owner/StoreSettings.tsx
@@ -181,25 +181,6 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
             </div>
           </div>
           <div>
-            <label htmlFor="store-email" className={labelStyle}>
-              이메일
-            </label>
-            <div className="relative">
-              <Mail
-                size={18}
-                className="absolute left-4 top-[26px] text-gray-400"
-              />
-              <input
-                id="store-email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="이메일 주소를 입력하세요"
-                className={`${inputStyle} pl-12`}
-              />
-            </div>
-          </div>
-          <div>
             <label className={labelStyle}>주소</label>
             <div className="relative">
               <MapPin
@@ -207,10 +188,9 @@ const StoreSettings: React.FC<StoreSettingsProps> = ({ storeId }) => {
                 className="absolute left-4 top-[26px] text-gray-400"
               />
               <input
+                readOnly
                 type="text"
                 value={address}
-                onChange={(e) => setAddress(e.target.value)}
-                placeholder="가게 주소를 입력하세요"
                 className={`${inputStyle} pl-12`}
               />
             </div>


### PR DESCRIPTION
## 💡 개요
브레이크 타임 내의 영업시간/브레이크타임 한번더 고지하는 부분 삭제, 및 가게관리 페이지 내의 주소창 block, 이메일란 삭제

## 🔢 관련 이슈 링크
- Closes #117

## 💻 작업내용
- 브레이크 타임 내의 영업시간/브레이크타임 텍스트 부분이 한번더 중복되기에 삭제하여 모달 간소화 작업 진행
- 가게 관리 페이지안에 가게 설정 탭에서 주소창은 읽기전용으로 변경하도록 수정
- 이메일란은 가게 이메일은 없기에 삭제 작업 진행

## 📌 변경사항PR
- [ ] FEAT: 새로운 기능 추가
- [x] FIX: 버그/오류 수정
- [ ] CHORE: 코드/내부 파일/설정 수정
- [ ] DOCS: 문서 수정(README 등)
- [ ] REFACTOR: 코드 리팩토링 (기능 변경 없음)
- [ ] TEST: 테스트 코드 추가/수정
- [ ] STYLE: 스타일 변경(포맷, 세미콜론 등)

## 🤔 추가 논의하고 싶은 내용
- N/A

## ✅ 체크리스트
- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌이 없다(또는 브랜치에서 충돌 해결 후 PR 업데이트 완료)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **UI 개선**
  * 매장 설정의 기본 정보 섹션에서 이메일 입력 필드를 제거하여 더 간결한 입력 화면 제공.
  * 주소 필드를 읽기 전용으로 변경해 직접 편집을 방지하고 표시 전용으로 전환.
  * 휴무 시간 모달에서 운영 시간 및 선택된 휴무 시간 표시를 제거하여 모달 하단이 간소화됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->