### PR TITLE
[Fix/#134] 예약금결제 스크롤 에러 수정

### DIFF
--- a/src/components/reservation/modals/PaymentModal.tsx
+++ b/src/components/reservation/modals/PaymentModal.tsx
@@ -209,7 +209,7 @@ export default function PaymentModal({
       className="fixed inset-0 z-60 flex items-center justify-center p-4"
       role="dialog"
       aria-modal="true"
-      aria-label="예약 내용 확인모달"
+      aria-label="예약금 결제 모달"
     >
       <button
         type="button"
@@ -220,10 +220,10 @@ export default function PaymentModal({
       <div
         className={cn(
           panelMotionClass(entered),
-          "relative z-10 w-[92vw] max-w-md max-h-[90vh] overflow-y-auto rounded-2xl bg-white shadow-xl overflow-hidden",
+          "relative z-10 flex w-[92vw] max-w-md max-h-[90vh] flex-col rounded-2xl bg-white shadow-xl",
         )}
       >
-        <div className="flex items-center justify-between px-5 py-4 border-b">
+        <div className="flex items-center justify-between px-5 py-4 border-b shrink-0">
           <h3 className="text-lg">예약금 결제</h3>
           <button
             type="button"
@@ -235,7 +235,7 @@ export default function PaymentModal({
             <X />
           </button>
         </div>
-        <div className="px-6 py-5 space-y-4">
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5 space-y-4">
           <div className="border rounded-xl p-4">
             <div className="text-sm text-muted-foreground">매장</div>
             <div className="mt-1 text-base truncate">{restaurant.name}</div>


### PR DESCRIPTION
## 🔢 관련 이슈 링크

- Closes #134 

## 📌 변경사항PR

- [ ] ✨Feature: 새로운 기능 추가
- [x] 🐞Bugfix: 버그/오류 수정
- [ ] 📃Docs: 문서 수정(README 등)
- [ ] 🔨Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] 🧪Test: 테스트 코드 추가/수정
- [ ] 🎨UI/UX: 디자인 및 사용성 수정
- [ ] ⚙️Setting: 기본 세팅 작업

## 💻 작업내용

예약금 결제 수단 선택 에서 스크롤이 되지않아서 결제버튼이 보이지 않는 에러가 발생.
모달 하단 영역이 짤리면서 접근이 어려운 문제였기에 수정 진행.

- 모달 전체 레이아웃을 flex-col 구조로 변경해서 헤더는 고정되고, 내부 스크롤만되도록 수정.
- 모달 최대 높이 기준에서 하단에 있는 버튼까지 정상접근 가능하도록 수정


### 변경전
<img width="1275" height="882" alt="image" src="https://github.com/user-attachments/assets/45c3096a-529f-4c0c-ab00-cfda33c62603" />

### 변경후
<img width="1104" height="891" alt="image" src="https://github.com/user-attachments/assets/b1082245-c619-45ed-8993-e2d44a0b8d37" />


## 🪧 미완성 작업

N/A

## 🤔 논의 사항 및 참고 사항

현재는 내부 스크롤이 보이도록 유지했는데, 혹시 스크롤바에 대해서는 추후 디자인 변경에 맞춰서 추가 논의 진행하면 될것같습니다

## ✅ 체크리스트

- [x] 브랜치는 잘 맞게 올렸는지
- [x] 관련 이슈를 맞게 연결했는지
- [x] 로컬에서 정상 동작을 확있했는지
- [x] 충돌은 없는지
- [x] 불필요한 console.log 제거했는지
